### PR TITLE
fix: stabilize workspace terminal node-pty startup

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -274,7 +274,7 @@ window.__ModuleLoader__.load({
 			constructor(code, detail) {
 				const copy = COPY[code];
 				const safe = detail === void 0 ? void 0 : redactSecrets(detail);
-				const messageZh = safe && (code === "GIT_FAILED" || code === "LLM_FAILED") ? `${copy.messageZh} ${safe}` : copy.messageZh;
+				const messageZh = safe && (code === "GIT_FAILED" || code === "LLM_FAILED" || code === "TERM_FAILED") ? `${copy.messageZh} ${safe}` : copy.messageZh;
 				super(`${code}: ${messageZh}`);
 				this.name = "GitError";
 				this.code = code;

--- a/lib/index.js
+++ b/lib/index.js
@@ -232,7 +232,7 @@ var GitError = class extends Error {
 	constructor(code, detail) {
 		const copy = COPY[code];
 		const safe = detail === void 0 ? void 0 : redactSecrets(detail);
-		const messageZh = safe && (code === "GIT_FAILED" || code === "LLM_FAILED") ? `${copy.messageZh} ${safe}` : copy.messageZh;
+		const messageZh = safe && (code === "GIT_FAILED" || code === "LLM_FAILED" || code === "TERM_FAILED") ? `${copy.messageZh} ${safe}` : copy.messageZh;
 		super(`${code}: ${messageZh}`);
 		this.name = "GitError";
 		this.code = code;
@@ -3696,6 +3696,8 @@ const ALLOWED_SHELL = /^(bash|zsh|sh|dash|pwsh|powershell|cmd)$/;
 const ALLOWED_ABS = /^\/(bin|usr\/bin|usr\/local\/bin)\/(bash|zsh|sh|dash)$/;
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
+const PTY_PROBE_TIMEOUT_MS = 5e3;
+const RUN_AS_NODE = "ELECTRON_RUN_AS_NODE";
 function looksLikeAllowedShell(path) {
 	const trimmed = path.trim();
 	if (ALLOWED_ABS.test(trimmed)) return true;
@@ -3761,14 +3763,130 @@ async function loadNodePty() {
 	try {
 		return await import("node-pty");
 	} catch {
-		const candidates = [join(homedir(), ".dsh/profiles/node_modules/node-pty"), join(process.cwd(), "node_modules/node-pty")];
+		const candidates = [
+			join(homedir(), ".dsh/profiles/desktop/node_modules/node-pty"),
+			join(homedir(), ".dsh/profiles/node_modules/node-pty"),
+			join(process.cwd(), "node_modules/node-pty")
+		];
 		for (const dir of candidates) try {
 			return createRequire(join(dir, "package.json"))(dir);
 		} catch {}
 		throw new GitError("TERM_FAILED");
 	}
 }
+async function resolveNodePtyManifest() {
+	const require = createRequire(import.meta.url);
+	try {
+		return require.resolve("node-pty/package.json");
+	} catch {
+		const candidates = [
+			join(homedir(), ".dsh/profiles/desktop/node_modules/node-pty/package.json"),
+			join(homedir(), ".dsh/profiles/node_modules/node-pty/package.json"),
+			join(process.cwd(), "node_modules/node-pty/package.json")
+		];
+		for (const manifest of candidates) try {
+			await access(manifest, constants.R_OK);
+			return manifest;
+		} catch {}
+		throw new GitError("TERM_FAILED", "node-pty is not installed or cannot be resolved");
+	}
+}
+function ptyProbeCode(manifest, bin, cwd, env) {
+	const childEnv = termColorEnv(env, cwd);
+	return [
+		"const { createRequire } = require('node:module')",
+		"const pty = createRequire(" + JSON.stringify(manifest) + ")('node-pty')",
+		"const term = pty.spawn(" + JSON.stringify(bin) + ", [], {",
+		"  name: 'xterm-256color',",
+		"  cols: 10,",
+		"  rows: 4,",
+		"  cwd: " + JSON.stringify(cwd) + ",",
+		"  env: " + JSON.stringify(childEnv) + ",",
+		"})",
+		"let done = false",
+		"term.onExit((event) => {",
+		"  if (done) return",
+		"  done = true",
+		"  process.exit(event.exitCode === 0 ? 0 : 1)",
+		"})",
+		"term.write('exit\\n')",
+		"setTimeout(() => {",
+		"  if (done) return",
+		"  done = true",
+		"  try { term.kill() } catch {}",
+		"  process.exit(0)",
+		"}, 250)",
+		""
+	].join("\n");
+}
+function runNodePtyProbe(code, cwd, env) {
+	return new Promise((resolve) => {
+		const childEnv = { ...env };
+		if (process.versions.electron !== void 0) childEnv[RUN_AS_NODE] = "1";
+		const child = spawn(process.execPath, ["-e", code], {
+			cwd,
+			env: childEnv,
+			stdio: [
+				"ignore",
+				"ignore",
+				"pipe"
+			]
+		});
+		let stderr = "";
+		let settled = false;
+		const finish = (result) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			resolve(result);
+		};
+		const timeout = setTimeout(() => {
+			try {
+				child.kill();
+			} catch {}
+			finish({
+				ok: false,
+				detail: "node-pty self-check timed out"
+			});
+		}, PTY_PROBE_TIMEOUT_MS);
+		child.stderr?.on("data", (chunk) => {
+			stderr = (stderr + chunk.toString("utf8")).slice(-4096);
+		});
+		child.on("error", (error) => {
+			finish({
+				ok: false,
+				detail: error.message
+			});
+		});
+		child.on("exit", (code, signal) => {
+			if (code === 0) finish({ ok: true });
+			else finish({
+				ok: false,
+				detail: stderr.trim() || `node-pty self-check exited with ${signal ?? code ?? "unknown status"}`
+			});
+		});
+	});
+}
+let ptyProbe;
+async function assertNodePtyAvailable(bin, cwd, env, runProbe = runNodePtyProbe) {
+	if (env.DSH_WORKBENCH_DISABLE_PTY === "1") throw new GitError("TERM_FAILED", "DSH_WORKBENCH_DISABLE_PTY is set");
+	if (env.DSH_WORKBENCH_SKIP_PTY_PROBE === "1") return;
+	const run = async () => {
+		const result = await runProbe(ptyProbeCode(runProbe === runNodePtyProbe ? await resolveNodePtyManifest() : "node-pty/package.json", bin, cwd, env), cwd, env);
+		if (!result.ok) throw new GitError("TERM_FAILED", result.detail ?? "node-pty self-check failed");
+	};
+	if (runProbe !== runNodePtyProbe) {
+		await run();
+		return;
+	}
+	if (ptyProbe === void 0) ptyProbe = run().catch((error) => {
+		ptyProbe = void 0;
+		throw error;
+	});
+	await ptyProbe;
+}
 async function defaultSpawnPty(bin, cwd, cols, rows, env) {
+	await assertNodePtyAvailable(bin, cwd, env);
 	return (await loadNodePty()).spawn(bin, [], {
 		name: "xterm-256color",
 		cols,

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lightningcss": "^1.32.0",
     "marked": "^18.0.9",
     "mermaid": "^11.16.1",
+    "node-pty": "1.2.0-beta.15",
     "papaparse": "^5.6.0",
     "read-excel-file": "^9.3.10",
     "tsdown": "^0.22.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       mermaid:
         specifier: ^11.16.1
         version: 11.16.1
+      node-pty:
+        specifier: 1.2.0-beta.15
+        version: 1.2.0-beta.15
       papaparse:
         specifier: ^5.6.0
         version: 5.6.0
@@ -1244,8 +1247,14 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-pty@1.2.0-beta.15:
+    resolution: {integrity: sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==}
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -2719,7 +2728,13 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  node-addon-api@7.1.1: {}
+
   node-int64@0.4.0: {}
+
+  node-pty@1.2.0-beta.15:
+    dependencies:
+      node-addon-api: 7.1.1
 
   obug@2.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  node-pty: true

--- a/src/host/terminal.ts
+++ b/src/host/terminal.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -15,6 +16,9 @@ const ALLOWED_SHELL = /^(bash|zsh|sh|dash|pwsh|powershell|cmd)$/
 const ALLOWED_ABS = /^\/(bin|usr\/bin|usr\/local\/bin)\/(bash|zsh|sh|dash)$/
 const DEFAULT_COLS = 80
 const DEFAULT_ROWS = 24
+const PTY_PROBE_TIMEOUT_MS = 5000
+const MAX_PROBE_STDERR = 4096
+const RUN_AS_NODE = 'ELECTRON_RUN_AS_NODE'
 
 export interface TerminalHello {
   cwd: string
@@ -114,17 +118,21 @@ function writeSse(res: ServerResponse, event: TerminalEvent): void {
   res.write(`data: ${JSON.stringify(event)}\n\n`)
 }
 
-async function loadNodePty(): Promise<{ spawn: (file: string, args: string[], options: Record<string, unknown>) => {
-  write(data: string): void
-  resize(cols: number, rows: number): void
-  kill(): void
-  onData(handler: (data: string) => void): { dispose(): void }
-  onExit(handler: (event: { exitCode: number; signal?: number }) => void): { dispose(): void }
-} }> {
+interface NodePtyModule {
+  spawn(file: string, args: string[], options: Record<string, unknown>): PtyHandle
+}
+
+interface PtyProbeResult {
+  ok: boolean
+  detail?: string
+}
+
+async function loadNodePty(): Promise<NodePtyModule> {
   try {
     return await import('node-pty')
   } catch {
     const candidates = [
+      join(homedir(), '.dsh/profiles/desktop/node_modules/node-pty'),
       join(homedir(), '.dsh/profiles/node_modules/node-pty'),
       join(process.cwd(), 'node_modules/node-pty'),
     ]
@@ -137,7 +145,118 @@ async function loadNodePty(): Promise<{ spawn: (file: string, args: string[], op
   }
 }
 
+
+async function resolveNodePtyManifest(): Promise<string> {
+  const require = createRequire(import.meta.url)
+  try {
+    return require.resolve('node-pty/package.json')
+  } catch {
+    const candidates = [
+      join(homedir(), '.dsh/profiles/desktop/node_modules/node-pty/package.json'),
+      join(homedir(), '.dsh/profiles/node_modules/node-pty/package.json'),
+      join(process.cwd(), 'node_modules/node-pty/package.json'),
+    ]
+    for (const manifest of candidates) {
+      try {
+        await access(manifest, constants.R_OK)
+        return manifest
+      } catch { /* try next */ }
+    }
+    throw new GitError('TERM_FAILED', 'node-pty is not installed or cannot be resolved')
+  }
+}
+
+function ptyProbeCode(manifest: string, bin: string, cwd: string, env: NodeJS.ProcessEnv): string {
+  const childEnv = termColorEnv(env, cwd)
+  return [
+    "const { createRequire } = require('node:module')",
+    'const pty = createRequire(' + JSON.stringify(manifest) + ")('node-pty')",
+    'const term = pty.spawn(' + JSON.stringify(bin) + ', [], {',
+    "  name: 'xterm-256color',",
+    '  cols: 10,',
+    '  rows: 4,',
+    '  cwd: ' + JSON.stringify(cwd) + ',',
+    '  env: ' + JSON.stringify(childEnv) + ',',
+    '})',
+    'let done = false',
+    'term.onExit((event) => {',
+    '  if (done) return',
+    '  done = true',
+    '  process.exit(event.exitCode === 0 ? 0 : 1)',
+    '})',
+    "term.write('exit\\n')",
+    'setTimeout(() => {',
+    '  if (done) return',
+    '  done = true',
+    '  try { term.kill() } catch {}',
+    '  process.exit(0)',
+    '}, 250)',
+    '',
+  ].join('\n')
+}
+
+function runNodePtyProbe(code: string, cwd: string, env: NodeJS.ProcessEnv): Promise<PtyProbeResult> {
+  return new Promise((resolve) => {
+    const childEnv = { ...env }
+    if (process.versions.electron !== undefined) childEnv[RUN_AS_NODE] = '1'
+    const child = spawn(process.execPath, ['-e', code], { cwd, env: childEnv, stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+    let settled = false
+    const finish = (result: PtyProbeResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve(result)
+    }
+    const timeout = setTimeout(() => {
+      try { child.kill() } catch {}
+      finish({ ok: false, detail: 'node-pty self-check timed out' })
+    }, PTY_PROBE_TIMEOUT_MS)
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr = (stderr + chunk.toString('utf8')).slice(-MAX_PROBE_STDERR)
+    })
+    child.on('error', error => { finish({ ok: false, detail: error.message }) })
+    child.on('exit', (code, signal) => {
+      if (code === 0) finish({ ok: true })
+      else finish({
+        ok: false,
+        detail: stderr.trim() || `node-pty self-check exited with ${signal ?? code ?? 'unknown status'}`,
+      })
+    })
+  })
+}
+
+let ptyProbe: Promise<void> | undefined
+
+export async function assertNodePtyAvailable(
+  bin: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  runProbe: (code: string, cwd: string, env: NodeJS.ProcessEnv) => Promise<PtyProbeResult> = runNodePtyProbe,
+): Promise<void> {
+  if (env.DSH_WORKBENCH_DISABLE_PTY === '1') {
+    throw new GitError('TERM_FAILED', 'DSH_WORKBENCH_DISABLE_PTY is set')
+  }
+  if (env.DSH_WORKBENCH_SKIP_PTY_PROBE === '1') return
+  const run = async (): Promise<void> => {
+    const manifest = runProbe === runNodePtyProbe ? await resolveNodePtyManifest() : 'node-pty/package.json'
+    const result = await runProbe(ptyProbeCode(manifest, bin, cwd, env), cwd, env)
+    if (!result.ok) throw new GitError('TERM_FAILED', result.detail ?? 'node-pty self-check failed')
+  }
+  if (runProbe !== runNodePtyProbe) {
+    await run()
+    return
+  }
+  if (ptyProbe === undefined) {
+    ptyProbe = run().catch(error => {
+      ptyProbe = undefined
+      throw error
+    })
+  }
+  await ptyProbe
+}
 async function defaultSpawnPty(bin: string, cwd: string, cols: number, rows: number, env: NodeJS.ProcessEnv): Promise<PtyHandle> {
+  await assertNodePtyAvailable(bin, cwd, env)
   const pty = await loadNodePty()
   return pty.spawn(bin, [], {
     name: 'xterm-256color',

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -193,7 +193,7 @@ export class GitError extends Error {
   constructor(code: GitErrorCode, detail?: string) {
     const copy = COPY[code]
     const safe = detail === undefined ? undefined : redactSecrets(detail)
-    const messageZh = safe && (code === 'GIT_FAILED' || code === 'LLM_FAILED')
+    const messageZh = safe && (code === 'GIT_FAILED' || code === 'LLM_FAILED' || code === 'TERM_FAILED')
       ? `${copy.messageZh} ${safe}`
       : copy.messageZh
     super(`${code}: ${messageZh}`)

--- a/tests/terminal.spec.ts
+++ b/tests/terminal.spec.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { describe, expect, it } from 'vitest'
-import { clampSize, pickShell, termColorEnv, TerminalHub, type PtyHandle } from '../src/host/terminal.ts'
+import { assertNodePtyAvailable, clampSize, pickShell, termColorEnv, TerminalHub, type PtyHandle } from '../src/host/terminal.ts'
 
 function fakePty() {
   const written: string[] = []
@@ -42,6 +42,37 @@ describe('clampSize', () => {
     expect(clampSize(Number.NaN, 10, 400, 80)).toBe(80)
     expect(clampSize(2, 10, 400, 80)).toBe(10)
     expect(clampSize(9999, 10, 400, 80)).toBe(400)
+  })
+})
+
+
+describe('assertNodePtyAvailable', () => {
+  it('generates a real multiline probe script for node -e', async () => {
+    let probeCode = ''
+    await assertNodePtyAvailable('/bin/sh', '/repo', {
+      DSH_WORKBENCH_SKIP_PTY_PROBE: '0',
+    }, async (code) => {
+      probeCode = code
+      return { ok: true }
+    })
+    expect(probeCode).toContain('\nconst pty =')
+    expect(probeCode).not.toContain('\\nconst pty =')
+  })
+
+  it('turns a failed out-of-process node-pty probe into a structured terminal error', async () => {
+    await expect(assertNodePtyAvailable('/bin/sh', '/repo', {}, async () => ({
+      ok: false,
+      detail: 'posix_spawn failed: No such file or directory',
+    }))).rejects.toMatchObject({
+      code: 'TERM_FAILED',
+      messageZh: expect.stringContaining('posix_spawn failed'),
+    })
+  })
+
+  it('allows explicit probe bypass for known-good host environments', async () => {
+    await expect(assertNodePtyAvailable('/bin/sh', '/repo', {
+      DSH_WORKBENCH_SKIP_PTY_PROBE: '1',
+    }, async () => ({ ok: false, detail: 'should not run' }))).resolves.toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

- add node-pty as an explicit plugin dependency
- validate node-pty in an out-of-process startup probe before spawning the workspace shell
- surface node-pty startup failures through structured TERM_FAILED details
- allow node-pty install/prebuild scripts through pnpm workspace config

## Verification

- pnpm install --frozen-lockfile
- pnpm vitest run tests/terminal.spec.ts
- pnpm build
- verified node-pty can spawn /bin/zsh under DSH Desktop Electron