### PR TITLE
feat(workbench): drag a file-tree node onto the composer to append its path

### DIFF
--- a/src/client/workbench/FileTree.tsx
+++ b/src/client/workbench/FileTree.tsx
@@ -642,8 +642,17 @@ export function FileTree({ client, workspaceId, workspaceTitle, activePath, onOp
       return
     }
     setDragSource(path)
-    event.dataTransfer.effectAllowed = 'move'
+    // copyMove, not move: the composer drop sets dropEffect 'copy', and per
+    // the HTML DnD effect-compatibility rule a dropEffect outside
+    // effectAllowed cancels the drop (Chrome shows the no-drop cursor and the
+    // drop event never fires), which silently broke drag-to-composer.
+    event.dataTransfer.effectAllowed = 'copyMove'
     event.dataTransfer.setData('application/x-dsh-path', path)
+    // Standard-type fallback: only text/* data is readable during dragover in
+    // Firefox, so a custom-type-only drag could never enable the drop there;
+    // text/plain also feeds the native drop-into-textarea path when our own
+    // drop handler cannot run (e.g. cross-document drags).
+    event.dataTransfer.setData('text/plain', path)
   }
 
   const handleDragEnd = (): void => {

--- a/src/client/workbench/Workbench.tsx
+++ b/src/client/workbench/Workbench.tsx
@@ -475,6 +475,79 @@ function WorkbenchInner(props: WorkbenchProps) {
     return () => { window.removeEventListener('keydown', onKey, true) }
   }, [openNewTerminal])
 
+  /**
+   * Dragging a file-tree node onto the composer appends the quoted absolute
+   * path to the draft. The composer is dsh shell UI ([data-composer-seat] >
+   * textarea), outside this plugin's React tree, so we listen on window in
+   * the capture phase and only act when the drop target sits inside it.
+   */
+  useEffect(() => {
+    const workspacePath = workspace?.path
+    if (workspacePath === undefined) return
+    const root = workspacePath.replace(/\/+$/, '')
+    const relPathOf = (dt: DataTransfer | null): string | null => {
+      if (dt === null) return null
+      const rel = dt.getData('application/x-dsh-path')
+      return rel === '' ? null : rel
+    }
+    // Gate dragover on the TYPES list, not getData: the types array is
+    // readable during dragover in every engine, while custom-type DATA is not
+    // (Firefox only exposes text/* there) — a getData gate would never call
+    // preventDefault on Firefox and the drop would stay forbidden.
+    const dragCarriesPath = (dt: DataTransfer | null): boolean =>
+      dt !== null && dt.types.includes('application/x-dsh-path')
+    const seatOf = (target: EventTarget | null): HTMLElement | null => {
+      if (!(target instanceof Element)) return null
+      return target.closest<HTMLElement>('[data-composer-seat]')
+    }
+    const clearMark = (seat: HTMLElement): void => {
+      seat.removeAttribute('data-dsh-drop-target')
+    }
+    const onDragOver = (event: DragEvent): void => {
+      if (!dragCarriesPath(event.dataTransfer)) return
+      const seat = seatOf(event.target)
+      if (seat === null) return
+      event.preventDefault()
+      // 'copy' is legal now: the drag source declares effectAllowed 'copyMove'.
+      if (event.dataTransfer !== null) event.dataTransfer.dropEffect = 'copy'
+      seat.setAttribute('data-dsh-drop-target', '')
+    }
+    const onDragLeave = (event: DragEvent): void => {
+      const seat = seatOf(event.target)
+      if (seat !== null) clearMark(seat)
+    }
+    const onDrop = (event: DragEvent): void => {
+      const rel = relPathOf(event.dataTransfer)
+      const seat = seatOf(event.target)
+      if (rel === null || seat === null) return
+      event.preventDefault()
+      event.stopPropagation()
+      clearMark(seat)
+      const textarea = seat.querySelector<HTMLTextAreaElement>('textarea')
+      if (textarea === null) return
+      const full = root === '' ? rel : `${root}/${rel}`
+      const quoted = `"${full}"`
+      const current = textarea.value
+      const sep = current === '' || /\s$/.test(current) ? '' : ' '
+      const next = current + sep + quoted
+      // React-controlled textarea: write via the native setter, then dispatch
+      // an input event so the composer's onChange picks the draft up.
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set
+      setter?.call(textarea, next)
+      textarea.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: quoted }))
+      textarea.focus()
+      textarea.setSelectionRange(next.length, next.length)
+    }
+    window.addEventListener('dragover', onDragOver, true)
+    window.addEventListener('dragleave', onDragLeave, true)
+    window.addEventListener('drop', onDrop, true)
+    return () => {
+      window.removeEventListener('dragover', onDragOver, true)
+      window.removeEventListener('dragleave', onDragLeave, true)
+      window.removeEventListener('drop', onDrop, true)
+    }
+  }, [workspace?.path])
+
   const closeTab = (id: string): void => {
     closeTabs([id])
   }

--- a/src/client/workbench/ide-host.css.ts
+++ b/src/client/workbench/ide-host.css.ts
@@ -93,6 +93,12 @@ export const IDE_HOST_CSS = `
   min-width: 0;
   overflow: visible;
 }
+/* File-tree drag over the composer: outline the input seat so dropping is obvious. */
+[data-composer-seat][data-dsh-drop-target]{
+  outline: 2px dashed var(--dsw-alias-accent-primary, #4c8dff);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
 `
 
 export function ensureIdeStyles(): void {


### PR DESCRIPTION
## What

Dragging a file or folder from the file tree onto the conversation composer appends the **quoted absolute path** to the draft (with a space separator if needed, cursor moved to the end).

## How it works

- The composer is dsh shell UI (`[data-composer-seat] > textarea`) living **outside** this plugin's React tree, so the plugin listens on `window` in the capture phase and only acts when the drop target is inside the composer seat.
- On drop, the draft is written through the **native textarea value setter** + a synthetic `InputEvent('input')`, so the composer's React `onChange` picks up the new draft value.
- The drop target is visually outlined with a dashed accent border (`[data-composer-seat][data-dsh-drop-target]`) while a valid drop is hovered.

## Cross-browser notes (why `copyMove` + `text/plain`)

- The drag source declares `effectAllowed = 'copyMove'` instead of `'move'`: the composer drop handler sets `dropEffect = 'copy'`, and per the HTML DnD effect-compatibility rule a `dropEffect` outside `effectAllowed` **cancels the drop** (Chrome shows the no-drop cursor and the drop event never fires).
- `dragover` is gated on `dataTransfer.types` (not `getData`): the types array is readable during `dragover` in every engine, while custom-type **data** is not (Firefox only exposes `text/*` there) — a `getData` gate would never call `preventDefault` on Firefox and the drop would stay forbidden.
- `text/plain` is also set so cross-document / native drop-into-textarea paths still receive something useful when our handler cannot run.

## Notes for maintainers

- Intentionally **no** rebuilt `lib/client.js` in this PR: CSS module class-name hashes in the committed bundle are derived from the build-time absolute path, so a local rebuild would add thousands of lines of hash noise. Please run `bash devops/build.sh` when merging.
- This PR is independent of #9 and #10 and can be merged in any order.