### PR TITLE
fix: 「添加命令」按钮 dark 主题下文字看不清 — 改用主题自适应前景色 token

### DIFF
--- a/src/client/ultra-slash/SlashPanel.module.css
+++ b/src/client/ultra-slash/SlashPanel.module.css
@@ -146,7 +146,9 @@
 .primary {
   background: var(--dsw-alias-brand-primary, #4f6ef7);
   border-color: var(--dsw-alias-brand-primary, #4f6ef7);
-  color: #fff;
+  /* Brand fill is light in dark themes; use the theme's on-brand foreground token
+     (white in light, dark in dark) so text stays legible on any theme. */
+  color: var(--dsw-alias-label-primary-foreground, #fff);
 }
 
 .danger {


### PR DESCRIPTION
## What（改动内容）

修复「插件命令」标签（SlashPanel）中主按钮（如「添加命令」）在 dark 主题下文字看不清的问题。

`src/client/ultra-slash/SlashPanel.module.css` 的 `.primary` 按钮文字色由硬编码 `#fff` 改为主题自适应 token `--dsw-alias-label-primary-foreground`（light 主题为白色、dark 主题为深色），token 未定义时回退 `#fff`。

## Why（原因）

`.primary` 的背景跟随 `--dsw-alias-brand-primary`，该 token 在 light 主题下为深蓝（bluish-1000），dark 主题下为**浅蓝（bluish-50）**。文字固定 `#fff` 在 light 下可读，但 dark 下浅蓝底 + 白字对比度趋近于零，按钮文字看不清。

`--dsw-alias-label-primary-foreground` 是设计系统（design-platform.css）中与品牌色成对定义的「品牌填充前景色」token，官方 ui-primitives 的 Button 主按钮正是此搭配（`background: button-primary-fill` + `color: label-primary-foreground`），可保证 light / dark / 自定义主题下文字对比度始终正确。

## 改动清单

- `src/client/ultra-slash/SlashPanel.module.css`：`.primary` 文字色 `#fff` → `var(--dsw-alias-label-primary-foreground, #fff)`（+3 / -1）

## 给维护者的注意事项

- 本 PR **只提交源码，未包含构建产物**（lib/index.js、lib/client.js）——上游 lib 的 CSS hash 依赖构建路径，本地重建会产生大量无关噪声；合并时请运行 `bash devops/build.sh` 重新生成 lib。