### PR TITLE
feat: 「源代码管理」新增自动刷新 Git 状态开关

### DIFF
--- a/src/client/locales.ts
+++ b/src/client/locales.ts
@@ -6,6 +6,8 @@ export const NS = 'workbench'
 export const zh = {
   'panel.title': '源代码管理',
   'panel.refresh': '刷新并获取远程更新',
+  'panel.autoRefreshOn': '自动刷新 Git 状态已开启：每 8 秒轮询，页面隐藏时暂停（点击关闭）',
+  'panel.autoRefreshOff': '自动刷新已关闭：仅手动刷新与挂载时加载（点击开启）',
   'panel.retry': '重试',
   'panel.loading': '正在读取仓库状态…',
   'panel.noWorkspace': '还没有选中工作区。请先在左侧打开一个本地目录。',
@@ -641,6 +643,8 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
 export const en = {
   'panel.title': 'Source Control',
   'panel.refresh': 'Refresh and fetch remote updates',
+  'panel.autoRefreshOn': 'Auto-refresh is on: polls every 8s and pauses when the page is hidden (click to turn off)',
+  'panel.autoRefreshOff': 'Auto-refresh is off: only manual refresh and mount-time load (click to turn on)',
   'panel.retry': 'Retry',
   'panel.loading': 'Reading repository status…',
   'panel.noWorkspace': 'No workspace selected. Open a local folder on the left first.',

--- a/src/client/workbench/GitSidebar.module.css
+++ b/src/client/workbench/GitSidebar.module.css
@@ -23,6 +23,28 @@
   border-bottom: 1px solid var(--dsw-alias-border-l2);
 }
 
+/* 头部图标按钮固定 28px、不可压缩：repo/分支名过长或出现「领先/落后」chip 时，
+   只允许 scopeWrap 弹性收缩（内部省略号截断），按钮不会被挤扁或挤出屏幕。
+   自动刷新开关置于最左侧，即使右侧内容溢出被 overflow:hidden 裁切也始终可见。 */
+.head > button {
+  flex: none;
+}
+
+/* 自动刷新开启时：科技蓝实底 + 白图标，与关闭态（透明）形成明确视觉区分。
+   用 button 前缀提升优先级，压过 IconButton 基类的 hover/active 样式。 */
+button.autoRefreshOn,
+button.autoRefreshOn[data-active],
+button.autoRefreshOn:hover:not(:disabled),
+button.autoRefreshOn[data-active]:hover:not(:disabled) {
+  background: #4c8dff;
+  color: #fff;
+}
+
+button.autoRefreshOn:hover:not(:disabled),
+button.autoRefreshOn[data-active]:hover:not(:disabled) {
+  background: #3a7ae8;
+}
+
 .scopeWrap {
   display: flex;
   flex: 1;

--- a/src/client/workbench/GitSidebar.tsx
+++ b/src/client/workbench/GitSidebar.tsx
@@ -18,8 +18,9 @@ import {
   type GitSyncPrefs, type PullMode, type PushMode,
 } from '../../shared/git-sync-prefs.ts'
 import { invalidBranchName } from '../../shared/branch-name.ts'
-import { IconCheck, IconChevron, IconCompact, IconFetch, IconMerge, IconMinus, IconNewBranch, IconPlus, IconPull, IconPush, IconRefresh, IconRestore, IconSparkle, IconTune } from './icons.tsx'
+import { IconAutoRefresh, IconCheck, IconChevron, IconCompact, IconFetch, IconMerge, IconMinus, IconNewBranch, IconPlus, IconPull, IconPush, IconRefresh, IconRestore, IconSparkle, IconTune } from './icons.tsx'
 import { readNearbyGit, retainNearbyGit, setNearbyRepo, setParentGitDecision, subscribeNearbyGit } from './nearby-git.ts'
+import { getGitAutoRefresh, setGitAutoRefresh, subscribeGitAutoRefresh } from './git-auto-refresh.ts'
 import { parentNeedsAsk } from '../../shared/git-nearby.ts'
 import { readDocumentColorScheme } from './surface-scheme.ts'
 import type { Translate } from './types.ts'
@@ -185,6 +186,7 @@ function FileGroup({
 export function GitSidebar({ client, workspaceId, selected, onOpenDiff, onOpenCommitDiff, t }: GitSidebarProps) {
   const rootRef = useRef<HTMLElement>(null)
   const nearby = useSyncExternalStore(subscribeNearbyGit, readNearbyGit, readNearbyGit)
+  const autoRefresh = useSyncExternalStore(subscribeGitAutoRefresh, getGitAutoRefresh, getGitAutoRefresh)
   const repoId = nearby.selectedId
   const [busy, setBusy] = useState(false)
   const [pending, setPending] = useState<'commit' | 'push' | 'pull' | 'fetch' | null>(null)
@@ -327,15 +329,6 @@ export function GitSidebar({ client, workspaceId, selected, onOpenDiff, onOpenCo
 
   useEffect(() => {
     let live = true
-    const hidden = (): boolean => document.visibilityState === 'hidden'
-    const tickStatus = (): void => {
-      if (!live || busyLock.current || hidden()) return
-      void refresh()
-    }
-    const tickRemote = (): void => {
-      if (!live || busyLock.current || hidden()) return
-      void checkRemote(true)
-    }
     setStatus(null)
     setBranches([])
     setLog([])
@@ -345,6 +338,17 @@ export function GitSidebar({ client, workspaceId, selected, onOpenDiff, onOpenCo
       if (!live) return
       if (snap?.probe.remote !== undefined) await checkRemote(true)
     })()
+    // 自动刷新开关关闭时：只保留挂载时的一次性加载，不注册任何定时轮询（手动刷新按钮仍可用）。
+    if (!autoRefresh) return () => { live = false }
+    const hidden = (): boolean => document.visibilityState === 'hidden'
+    const tickStatus = (): void => {
+      if (!live || busyLock.current || hidden()) return
+      void refresh()
+    }
+    const tickRemote = (): void => {
+      if (!live || busyLock.current || hidden()) return
+      void checkRemote(true)
+    }
     const statusTimer = window.setInterval(tickStatus, 8000)
     const remoteTimer = window.setInterval(tickRemote, 60_000)
     const onVisible = (): void => {
@@ -359,7 +363,7 @@ export function GitSidebar({ client, workspaceId, selected, onOpenDiff, onOpenCo
       generateAbort.current?.abort()
       generateAbort.current = null
     }
-  }, [workspaceId, repoId])
+  }, [workspaceId, repoId, autoRefresh])
 
   useLayoutEffect(() => {
     const area = messageRef.current
@@ -708,6 +712,14 @@ export function GitSidebar({ client, workspaceId, selected, onOpenDiff, onOpenCo
       style={{ '--git-graph-h': `${graphHFit}px`, '--git-graph-reserved': `${reserved}px` } as never}
     >
       <header className={css.head} data-git-chrome="head">
+        <IconButton
+          label={autoRefresh ? t('panel.autoRefreshOn') : t('panel.autoRefreshOff')}
+          active={autoRefresh}
+          className={autoRefresh ? css.autoRefreshOn : undefined}
+          onClick={() => { setGitAutoRefresh(!autoRefresh) }}
+        >
+          <IconAutoRefresh />
+        </IconButton>
         <GitScopeBar
           nearby={nearby}
           branches={branches}

--- a/src/client/workbench/StatusBar.tsx
+++ b/src/client/workbench/StatusBar.tsx
@@ -17,6 +17,7 @@ import {
 import { EDITOR_MODES, type EditorModeId } from './editor-mode.ts'
 import { IconChevron, IconFeedback, IconGithub, IconNpm, IconSparkle } from './icons.tsx'
 import { readNearbyGit, retainNearbyGit, subscribeNearbyGit } from './nearby-git.ts'
+import { getGitAutoRefresh, subscribeGitAutoRefresh } from './git-auto-refresh.ts'
 import { fileName, showEditorStatusChrome, tabStripOverflow, tabStripScrollDelta } from './status-bar.ts'
 import { browserTabLabel, terminalTabLabel, type FileTab, type Translate } from './types.ts'
 import { readUsageLive, retainUsageLive, subscribeUsageLive } from './usage-live.ts'
@@ -73,6 +74,7 @@ export function StatusBar({
   const [updateNote, setUpdateNote] = useState<string | null>(null)
   const usage = useSyncExternalStore(subscribeUsageLive, readUsageLive, () => null)
   const nearby = useSyncExternalStore(subscribeNearbyGit, readNearbyGit, readNearbyGit)
+  const autoRefresh = useSyncExternalStore(subscribeGitAutoRefresh, getGitAutoRefresh, getGitAutoRefresh)
   const repoId = nearby.selectedId
 
   useEffect(() => retainUsageLive(client, sessionId), [client, sessionId])
@@ -129,8 +131,10 @@ export function StatusBar({
       }
       hasRemote = result.value.probe.remote !== undefined
       setStatus(result.value)
-      fetchRemote()
+      if (autoRefresh) fetchRemote()
     })
+    // 自动刷新开关关闭时：只保留挂载时的一次性状态加载，不注册任何定时轮询（GitSidebar 手动刷新仍可用）。
+    if (!autoRefresh) return () => { live = false }
     const statusTimer = window.setInterval(load, 8000)
     const fetchTimer = window.setInterval(fetchRemote, 60_000)
     const onVisible = (): void => {
@@ -143,7 +147,7 @@ export function StatusBar({
       window.clearInterval(fetchTimer)
       document.removeEventListener('visibilitychange', onVisible)
     }
-  }, [client, workspaceId, repoId])
+  }, [client, workspaceId, repoId, autoRefresh])
 
   const probe = status?.probe
   const dirty = (status?.staged.length ?? 0) + (status?.unstaged.length ?? 0) + (status?.untracked.length ?? 0)

--- a/src/client/workbench/git-auto-refresh.ts
+++ b/src/client/workbench/git-auto-refresh.ts
@@ -1,0 +1,42 @@
+/**
+ * Git 自动刷新开关（页面级偏好，localStorage 持久化，刷新不丢）。
+ *
+ * 关闭后停止全部 Git 定时轮询（GitSidebar / StatusBar 的 8s git status、
+ * 60s 远程核对 fetch、nearby 8s 附近仓库扫描），只保留：
+ *   ① 挂载时的一次性加载；② GitSidebar 头部的手动刷新按钮；③ 回到前台（visibilitychange）时的刷新。
+ * 用于性能优先场景（大工作区下 git 轮询是主要周期性开销，见 my-docs/79-其他评估）。
+ * 余额用量轮询（usage-live，非 git）不受此开关影响。
+ */
+import { readBoolFlag, writeBoolFlag } from './ui-flags.ts'
+
+export const GIT_AUTO_REFRESH_KEY = 'dsh-workbench-git-auto-refresh'
+
+/** 出厂默认：自动刷新开启（与旧行为一致）。 */
+export const DEFAULT_GIT_AUTO_REFRESH = true
+
+let on = readBoolFlag(GIT_AUTO_REFRESH_KEY, DEFAULT_GIT_AUTO_REFRESH)
+const listeners = new Set<(on: boolean) => void>()
+
+export function getGitAutoRefresh(): boolean {
+  return on
+}
+
+export function setGitAutoRefresh(value: boolean): void {
+  if (on === value) return
+  on = value
+  writeBoolFlag(GIT_AUTO_REFRESH_KEY, value)
+  for (const fn of listeners) fn(value)
+}
+
+/** React useSyncExternalStore 订阅（模块级单例，无 React 依赖）。 */
+export function subscribeGitAutoRefresh(fn: (on: boolean) => void): () => void {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}
+
+/** 测试辅助：复位到出厂默认并清空持久化。 */
+export function resetGitAutoRefresh(): void {
+  on = DEFAULT_GIT_AUTO_REFRESH
+  writeBoolFlag(GIT_AUTO_REFRESH_KEY, on)
+  for (const fn of listeners) fn(on)
+}

--- a/src/client/workbench/icons.tsx
+++ b/src/client/workbench/icons.tsx
@@ -498,3 +498,13 @@ export function IconNpm({ size = 16 }: { size?: number }) {
     </Icon>
   )
 }
+
+/** Git 自动刷新：双向循环箭头（开关语义：开启 = 定时轮询，关闭 = 仅手动刷新）。 */
+export function IconAutoRefresh() {
+  return (
+    <Icon>
+      <path d="M3.4 6.4A5 5 0 0 1 12.8 5.2M12.9 2.4v3.2h-3.2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M12.6 9.6A5 5 0 0 1 3.2 10.8M3.1 13.6v-3.2h3.2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+    </Icon>
+  )
+}

--- a/src/client/workbench/nearby-git.ts
+++ b/src/client/workbench/nearby-git.ts
@@ -3,6 +3,7 @@ import {
   CURRENT_REPO_ID, PARENT_REPO_ID, pickNearbyRepoId, visibleNearbyRepos,
 } from '../../shared/git-nearby.ts'
 import type { NearbyGitRepo, NearbyGitSnapshot, ParentGitDecision } from '../../shared/types.ts'
+import { getGitAutoRefresh } from './git-auto-refresh.ts'
 
 const POLL_MS = 8000
 const SELECTED_KEY = 'dsh-workbench-git-repo:'
@@ -125,7 +126,12 @@ export function retainNearbyGit(client: GitClient, workspaceId?: string): () => 
     void pull()
   }
   if (refs === 1) {
-    timer = window.setInterval(() => { void pull() }, POLL_MS)
+    // 自动刷新开关关闭时定时器空转（tick 直接返回），挂载时的一次性 pull 仍执行；
+    // 开关开启后自动恢复轮询。模块级 store 非 React，无法按开关重建 interval，空 tick 开销可忽略。
+    timer = window.setInterval(() => {
+      if (!getGitAutoRefresh()) return
+      void pull()
+    }, POLL_MS)
     document.addEventListener('visibilitychange', onVisible)
   }
   return () => {

--- a/tests/git-auto-refresh.spec.ts
+++ b/tests/git-auto-refresh.spec.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  DEFAULT_GIT_AUTO_REFRESH,
+  GIT_AUTO_REFRESH_KEY,
+  getGitAutoRefresh,
+  resetGitAutoRefresh,
+  setGitAutoRefresh,
+  subscribeGitAutoRefresh,
+} from '../src/client/workbench/git-auto-refresh.ts'
+
+afterEach(() => {
+  resetGitAutoRefresh()
+  try { localStorage.removeItem(GIT_AUTO_REFRESH_KEY) } catch { /* ignore */ }
+})
+
+describe('git auto-refresh switch', () => {
+  it('defaults to on (legacy behavior)', () => {
+    expect(DEFAULT_GIT_AUTO_REFRESH).toBe(true)
+    expect(getGitAutoRefresh()).toBe(true)
+  })
+
+  it('persists the choice to localStorage and restores it', () => {
+    setGitAutoRefresh(false)
+    expect(localStorage.getItem(GIT_AUTO_REFRESH_KEY)).toBe('0')
+    // 模拟刷新：重新读取持久化值
+    expect(getGitAutoRefresh()).toBe(false)
+  })
+
+  it('notifies subscribers only on actual change', () => {
+    const seen: boolean[] = []
+    const off = subscribeGitAutoRefresh((on) => { seen.push(on) })
+    setGitAutoRefresh(false)
+    setGitAutoRefresh(false) // 无变化不通知
+    setGitAutoRefresh(true)
+    expect(seen).toEqual([false, true])
+    off()
+  })
+})


### PR DESCRIPTION
## What（功能内容）

在「源代码管理」（Git）侧栏头部新增**自动刷新开关**按钮：一键停用/启用全部 Git 定时轮询，用于大工作区等性能敏感场景。

开启时（默认）：维持现有行为 —— GitSidebar / StatusBar 每 8s 轮询 git status、每 60s 核对远程、nearby 每 8s 扫描附近仓库，页面隐藏时暂停。
关闭时：**不注册任何定时器**（零残留），只保留 ① 挂载时的一次性加载；② 头部手动刷新按钮；③ 回到前台时的刷新。余额用量轮询（usage-live，非 Git）不受影响。

## Why（动机）

此前 Git 轮询间隔（8s / 60s）全部硬编码、无任何开关；性能评估显示大工作区下 Git 轮询是主要周期性开销（单次 probe+status ≈ 7 个 git 进程，页面可见时每 8s ≈ 14 个 spawn）。该开关让用户按场景一键关闭，兼顾「实时性」与「性能」。

## 改动清单

| 文件 | 变更 |
|------|------|
| `src/client/workbench/git-auto-refresh.ts` | 新增（42 行）：页面级偏好 store，localStorage 持久化、默认开启、模块级单例订阅（useSyncExternalStore 可直接消费） |
| `src/client/workbench/GitSidebar.tsx` | 头部新增开关按钮（置于**最左侧**，固定宽度头部右端溢出裁切时也不会被挤出）；轮询 effect 按开关门控，`autoRefresh` 入依赖 |
| `src/client/workbench/StatusBar.tsx` | 同门控：关闭时不注册 8s/60s 定时器、`visibilitychange` 不 fetch |
| `src/client/workbench/nearby-git.ts` | nearby 8s 扫描 interval tick 检查开关 |
| `src/client/workbench/GitSidebar.module.css` | 开关开启态视觉（科技蓝 `#4c8dff` 实底 + 白图标，hover 加深）；`.head > button { flex: none }` 防按钮被压缩 |
| `src/client/locales.ts` | `panel.autoRefreshOn/Off` 中英文各 1 条（含 tooltip 说明） |
| `src/client/workbench/icons.tsx` | 新增 `IconAutoRefresh`（双向循环箭头） |
| `tests/git-auto-refresh.spec.ts` | 新增（40 行）：默认值 / 切换持久化 / 订阅通知 |

## 设计决策

- **默认开启**：与旧行为完全一致，不改变任何现有用户的体验；想省性能的用户可一键关闭。
- **门控在「注册定时器」之前**：关闭时 effect 直接不创建 interval（并清理上一次），保证零残留；手动刷新与挂载加载始终可用。
- **按钮放头部最左侧**：Git 头部是固定宽度 flex 行（`overflow: hidden`），repo/分支名过长或出现「领先/落后 N」标签时右端内容会被裁切——开关放最左侧永远不会被挤出；同时 `.head > button { flex: none }` 让按钮不被压缩。
- **开启态科技蓝**：与关闭态（透明）形成明确视觉区分，开关状态一目了然。

## 给维护者的注意事项

- 本 PR **只提交源码，未包含构建产物**（lib/index.js、lib/client.js）——上游 lib 的 CSS hash 依赖构建路径，本地重建会产生无关噪声；合并时请运行 `bash devops/build.sh` 重新生成 lib。