### PR TITLE
fix: 全局会话监控两项缺陷修复（完成提醒跨页面持久化 + 提示音 AudioContext 共享复用）

### DIFF
--- a/src/client/workbench/SessionsPanel.tsx
+++ b/src/client/workbench/SessionsPanel.tsx
@@ -25,7 +25,7 @@ import {
   type WorkspaceListLike,
 } from './session-monitor.ts'
 import type { Translate } from './types.ts'
-import { useAckVersion, useBeepOn, useLoopReminder, useReminderInterval, type SessionSelectorHook, type WorkspaceSelectorHook } from './useSessionMonitor.ts'
+import { useAckVersion, useBeepOn, useLoopReminder, usePersistVersion, useReminderInterval, type SessionSelectorHook, type WorkspaceSelectorHook } from './useSessionMonitor.ts'
 import { IconButton } from './IconButton.tsx'
 import { IconBell, IconTimer } from './icons.tsx'
 import { SoundSettings } from './SoundSettings.tsx'
@@ -40,6 +40,7 @@ export function SessionsPanel({
   t: Translate
 }) {
   useAckVersion()
+  usePersistVersion()
   const list = useSessions((s) => s) as SessionListLike
   const wsSnapshot = useWorkspaces((s) => s) as WorkspaceListLike
   const wsItems = wsSnapshot.items ?? []

--- a/src/client/workbench/Workbench.tsx
+++ b/src/client/workbench/Workbench.tsx
@@ -79,7 +79,7 @@ import { DEFAULT_TERM_AI_OPEN, TERM_AI_OPEN_KEY, readBoolFlag, writeBoolFlag } f
 import { usePluginUpdate, visibleUpdate } from './UpdateBanner.tsx'
 import { updateTermSeed } from '../../shared/version.ts'
 import { useWorkspace } from './useWorkspace.ts'
-import { useAttentionCounts, useSessionBeep, playBuiltinSound, playCustomSound } from './useSessionMonitor.ts'
+import { useAttentionCounts, useAttentionPersist, useSessionBeep, playBuiltinSound, playCustomSound, sharedBeepRef } from './useSessionMonitor.ts'
 import { BUILTIN_SOUNDS } from '../../shared/workbench-sounds/builtins.ts'
 import {
   composerSeatOf,
@@ -271,14 +271,17 @@ function WorkbenchInner(props: WorkbenchProps) {
   const workspace = useWorkspace(useSessions, useWorkspaces)
   const workspaceId = workspace?.workspaceId
   const { attention, running: runningCount } = useAttentionCounts(useSessions, useWorkspaces)
+  // 持久化"完成未查看"提醒（跨页面会话恢复，始终挂载）
+  useAttentionPersist(useSessions, useWorkspaces)
   const openSession = useCallback((id: string): void => { props.sessions?.open?.(id) }, [props.sessions])
   const playSound = useCallback(() => {
-    const acRef = { ac: null as AudioContext | null }
     try {
       const soundId = localStorage.getItem('dsh-workbench-sound-id') ?? 'chime-ascending'
       const builtin = BUILTIN_SOUNDS.find(s => s.id === soundId)
       if (builtin) {
-        playBuiltinSound(builtin, acRef)
+        // 共享复用同一个 AudioContext（模块级，跨重挂载保留）：每次新建会被
+        // 浏览器自动播放策略/上下文数量上限击穿，导致有注意事项时一声不响。
+        playBuiltinSound(builtin, sharedBeepRef)
       } else {
         // Custom sound via HTTP
         playCustomSound(`/workbench-sounds/${soundId}`)

--- a/src/client/workbench/session-monitor.ts
+++ b/src/client/workbench/session-monitor.ts
@@ -80,13 +80,13 @@ export interface SessionGroups {
   current: string | undefined
 }
 
-/** 未读 = 完成且未查看：completed 事实由运行时维护（打开会话即清除），本地 ack 只记显式记认。 */
+/** 未读 = 完成且未查看：壳层 completed（运行时维护，打开会话即清除）+ 插件持久化记认（跨页面会话）双重来源，本地 ack 只记显式记认。 */
 export function isUnread(
   s: SessionRowLike,
   current: string | undefined,
   acked: ReadonlySet<string>,
 ): boolean {
-  return s.completed === true && s.id !== current && !acked.has(s.id)
+  return (s.completed === true || isPersistedUnread(s.id)) && s.id !== current && !acked.has(s.id)
 }
 
 function topRows(list: SessionListLike, archived?: ReadonlySet<string>): SessionRowLike[] {
@@ -200,6 +200,139 @@ export function projectOf(s: SessionRowLike, wsItems: readonly WorkspaceItemLike
   return ''
 }
 
+// —— 持久化"完成未查看"提醒（跨页面会话，满足全局语义）——
+//
+// 壳层 dsh 的 completed 提醒是页面会话期内存态：刷新/重开页面后，已 idle 会话的
+// 完成提醒不会重新武装，导致"实际需要被注意但列表不显示"。插件在 localStorage 持久化
+// 自己的完成记认，来源有二：
+//   ① running→idle 边沿（prevRunning 落盘，跨页面会话也能检测到：上页运行 → 本页 idle）；
+//   ② 壳层 completed 出现（本页武装）时兜底记入，防后续刷新丢失。
+// 清除时机：会话再次运行、会话成为当前（被查看）、显式标为已读、会话从列表消失。
+
+const ATTENTION_PERSIST_KEY = 'dsh-workbench-attention-persist-v1'
+
+interface PersistedAttention {
+  /** 上次观察到的 running 位（跨页面会话检测完成边沿）。 */
+  prevRunning: Record<string, boolean>
+  /** 完成未查看：sessionId -> 完成时间戳。 */
+  completedUnread: Record<string, number>
+}
+
+function loadPersistedAttention(): PersistedAttention {
+  try {
+    if (typeof localStorage === 'undefined') return { prevRunning: {}, completedUnread: {} }
+    const raw = localStorage.getItem(ATTENTION_PERSIST_KEY)
+    if (raw !== null) {
+      const parsed = JSON.parse(raw) as Partial<PersistedAttention>
+      return {
+        prevRunning: parsed.prevRunning ?? {},
+        completedUnread: parsed.completedUnread ?? {},
+      }
+    }
+  } catch { /* 存储不可用：静默降级为会话内态 */ }
+  return { prevRunning: {}, completedUnread: {} }
+}
+
+function savePersistedAttention(): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(ATTENTION_PERSIST_KEY, JSON.stringify(persistedAttention))
+  } catch { /* 存储不可用：静默降级 */ }
+}
+
+let persistedAttention = loadPersistedAttention()
+let persistVersion = 0
+const persistListeners = new Set<() => void>()
+
+function bumpPersist(): void {
+  persistVersion += 1
+  for (const fn of persistListeners) fn()
+}
+
+/** 持久化记认版本订阅（React useSyncExternalStore 用）。 */
+export function subscribePersist(fn: () => void): () => void {
+  persistListeners.add(fn)
+  return () => { persistListeners.delete(fn) }
+}
+
+export function getPersistVersion(): number {
+  return persistVersion
+}
+
+/** 持久化记认的完成未查看是否包含该会话。 */
+export function isPersistedUnread(id: string): boolean {
+  return persistedAttention.completedUnread[id] !== undefined
+}
+
+/** 测试辅助：清空持久化提醒状态（含 localStorage）。 */
+export function resetPersistedAttention(): void {
+  persistedAttention = { prevRunning: {}, completedUnread: {} }
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(ATTENTION_PERSIST_KEY)
+  } catch { /* ignore */ }
+  bumpPersist()
+}
+
+/**
+ * 从最新列表快照协调持久化提醒状态（挂在始终渲染的 WorkbenchInner 上调用）。
+ * ① running→idle 边沿（含跨页面会话）且非当前会话 → 记完成未查看；
+ * ② 壳层 completed 出现 → 记入持久化兜底；
+ * ③ 当前会话（被查看）→ 清除；再次运行 → 清除；会话消失 → 清理残留。
+ */
+export function reconcilePersistedAttention(list: SessionListLike, archived?: ReadonlySet<string>): void {
+  const current = list.current
+  const prev = persistedAttention.prevRunning
+  const unread = persistedAttention.completedUnread
+  let changed = false
+  const seen = new Set<string>()
+  for (const s of topRows(list, archived)) {
+    seen.add(s.id)
+    const wasRunning = prev[s.id]
+    if (wasRunning === true && !s.running) {
+      // 完成边沿（上页运行 / 本页刚停）→ 记完成未查看
+      if (s.id !== current && unread[s.id] === undefined) {
+        unread[s.id] = Date.now()
+        changed = true
+      }
+    } else if (s.running) {
+      if (unread[s.id] !== undefined) {
+        delete unread[s.id]
+        changed = true
+      }
+    }
+    if (s.completed === true && unread[s.id] === undefined) {
+      // 壳层本页武装的 completed → 持久化兜底，防后续刷新丢失
+      unread[s.id] = Date.now()
+      changed = true
+    }
+    if (s.id === current && unread[s.id] !== undefined) {
+      // 当前会话 = 正在查看 → 消费完成提醒（与壳层 select 即清除语义一致）
+      delete unread[s.id]
+      changed = true
+    }
+    if (prev[s.id] !== s.running) {
+      prev[s.id] = s.running
+      changed = true
+    }
+  }
+  for (const id of Object.keys(prev)) {
+    if (!seen.has(id)) {
+      delete prev[id]
+      changed = true
+    }
+  }
+  for (const id of Object.keys(unread)) {
+    if (!seen.has(id)) {
+      delete unread[id]
+      changed = true
+    }
+  }
+  if (changed) {
+    savePersistedAttention()
+    bumpPersist()
+  }
+}
+
 // —— 页面会话期共享状态（刷新后重置，与悬浮球的内存态一致）——
 
 let ackVersion = 0
@@ -231,8 +364,12 @@ export function isAcked(id: string): boolean {
 }
 
 export function ackSession(id: string): void {
-  if (ackIds.has(id)) return
+  if (ackIds.has(id) && persistedAttention.completedUnread[id] === undefined) return
   ackIds.add(id)
+  if (persistedAttention.completedUnread[id] !== undefined) {
+    delete persistedAttention.completedUnread[id]
+    savePersistedAttention()
+  }
   bumpAck()
 }
 
@@ -243,8 +380,15 @@ export function ackMany(ids: Iterable<string>): void {
       ackIds.add(id)
       changed = true
     }
+    if (persistedAttention.completedUnread[id] !== undefined) {
+      delete persistedAttention.completedUnread[id]
+      changed = true
+    }
   }
-  if (changed) bumpAck()
+  if (changed) {
+    savePersistedAttention()
+    bumpAck()
+  }
 }
 
 /** 测试辅助：清空页面会话期的已读记认。 */

--- a/src/client/workbench/useSessionMonitor.ts
+++ b/src/client/workbench/useSessionMonitor.ts
@@ -26,9 +26,12 @@ import {
   countRunning,
   getAckVersion,
   getBeepOn,
+  getPersistVersion,
+  reconcilePersistedAttention,
   setBeepOn,
   subscribeAck,
   subscribeBeep,
+  subscribePersist,
   type SessionListLike,
   type WorkspaceListLike,
 } from './session-monitor.ts'
@@ -47,6 +50,8 @@ export function useAttentionCounts(
   useWorkspaces: WorkspaceSelectorHook,
 ): AttentionCounts {
   const ackVersion = useSyncExternalStore(subscribeAck, getAckVersion, getAckVersion)
+  // 持久化"完成未查看"提醒变化时也要重算（reconcile 在 useEffect 里改模块态后 bump）。
+  const persistVersion = useSyncExternalStore(subscribePersist, getPersistVersion, getPersistVersion)
   // 归档集数组引用在未变化时保持稳定（workspaces 快照按 Object.is 比对选择器结果），
   // 故该订阅只在归档集合真正变化时触发重渲染。
   const archivedIds = useWorkspaces((state) => (state as WorkspaceListLike).archivedSessionIds) as
@@ -59,7 +64,34 @@ export function useAttentionCounts(
   const attention = useSessions((state) => countAttention(state, ackSnapshot(), archived)) as number
   const running = useSessions((state) => countRunning(state, archived)) as number
   void ackVersion
+  void persistVersion
   return { attention, running }
+}
+
+/**
+ * 持久化"完成未查看"提醒接线（挂在始终渲染的 WorkbenchInner 上，面板未打开也生效）：
+ * 订阅完整会话列表，任一变化即协调一次持久化记认（跨页面会话恢复完成提醒）。
+ */
+export function useAttentionPersist(
+  useSessions: SessionSelectorHook,
+  useWorkspaces: WorkspaceSelectorHook,
+): void {
+  const list = useSessions((s) => s) as SessionListLike
+  const archivedIds = useWorkspaces((state) => (state as WorkspaceListLike).archivedSessionIds) as
+    | string[]
+    | undefined
+  const archived = useMemo(() => {
+    const ids = archivedIds ?? []
+    return ids.length === 0 ? undefined : new Set(ids)
+  }, [archivedIds])
+  useEffect(() => {
+    reconcilePersistedAttention(list, archived)
+  }, [list, archived])
+}
+
+/** 持久化记认版本订阅（面板读取共享持久化状态时调用，触发重渲染）。 */
+export function usePersistVersion(): number {
+  return useSyncExternalStore(subscribePersist, getPersistVersion, getPersistVersion)
 }
 
 export function useAckVersion(): number {
@@ -98,6 +130,36 @@ function getAudioCtor(): typeof AudioContext | null {
   const webkitAC = (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
   return (typeof AudioContext !== 'undefined' ? AudioContext : webkitAC) ?? null
 }
+
+/**
+ * 全局共享的 AudioContext 持有者（Workbench 自动响铃用，模块级跨组件/重挂载复用）。
+ *
+ * V3 提示音升级（0055e1e）把 V1 的"单个复用 AudioContext"改成了每次响铃新建：
+ * ① 新 AudioContext 默认 suspended，resume() 需用户手势（自动播放策略）——循环提醒
+ *    与空闲时的首次提醒都发生在手势之外，resume 被拒 → 无声；
+ * ② 上下文数量上限（Chrome 约 6 个）——每次响铃泄漏一个，循环提醒每 10s 一个，
+ *    约 1 分钟后 new AudioContext() 直接抛错，被 catch 静默吞掉 → 永久无声。
+ * 共享复用 + 首次用户手势解锁后上下文常驻 running，所有响铃稳定出声（V1 等效行为）。
+ */
+export const sharedBeepRef: { current: { ac: AudioContext | null } } = { current: { ac: null } }
+
+let unlockWired = false
+
+/** 首次用户手势（点击/按键）时恢复共享上下文，此后所有响铃无需再等手势。 */
+function wireGestureUnlock(): void {
+  if (unlockWired || typeof window === 'undefined') return
+  unlockWired = true
+  const unlock = (): void => {
+    const ac = sharedBeepRef.current.ac
+    if (ac !== null && ac.state === 'suspended') {
+      ac.resume().catch(() => { /* 仍被策略阻止：下个手势再试 */ })
+    }
+  }
+  window.addEventListener('pointerdown', unlock)
+  window.addEventListener('keydown', unlock)
+}
+
+wireGestureUnlock()
 
 /**
  * Play a built-in sound using Web Audio synthesis.

--- a/tests/session-monitor.spec.ts
+++ b/tests/session-monitor.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ackMany,
   ackSession,
@@ -9,12 +9,15 @@ import {
   getBeepOn,
   groupSessions,
   isAcked,
+  isPersistedUnread,
   isUnread,
   pendingLabelKey,
   projectOf,
+  reconcilePersistedAttention,
   relativeTime,
   resetAckStore,
   resetBeepStore,
+  resetPersistedAttention,
   sessionStatsOf,
   setBeepOn,
   subscribeAck,
@@ -48,6 +51,7 @@ const emptyAck = new Set<string>()
 afterEach(() => {
   resetAckStore()
   resetBeepStore()
+  resetPersistedAttention()
 })
 
 describe('isUnread', () => {
@@ -273,5 +277,90 @@ describe('page-session beep store', () => {
     setBeepOn(true)
     expect(seen).toEqual([false, true])
     off()
+  })
+})
+
+describe('persisted attention (跨页面会话的完成未查看记认)', () => {
+  it('arms completed-unread on the running→idle edge and feeds isUnread/countAttention', () => {
+    // 页面 1：b 正在运行（首次观察记录 running 位）
+    reconcilePersistedAttention(list([session({ id: 'b', running: true })], 'a'))
+    expect(isPersistedUnread('b')).toBe(false)
+    // b 完成（非当前会话）
+    reconcilePersistedAttention(list([session({ id: 'b', running: false })], 'a'))
+    expect(isPersistedUnread('b')).toBe(true)
+    // 即使壳层 completed 未标记，插件记认也计入未读
+    expect(isUnread(session({ id: 'b', running: false }), undefined, emptyAck)).toBe(true)
+    expect(countAttention(list([session({ id: 'b' })], 'a'), emptyAck)).toBe(1)
+    const groups = groupSessions(list([session({ id: 'b' })], 'a'), emptyAck)
+    expect(groups.completed.map((s) => s.id)).toEqual(['b'])
+  })
+
+  it('restores completed-unread across a page reload via localStorage', async () => {
+    // 安装 localStorage mock（node 环境默认无）
+    const store = new Map<string, string>()
+    const localStorageMock = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, v) },
+      removeItem: (k: string) => { store.delete(k) },
+      clear: () => { store.clear() },
+      key: () => null,
+      length: 0,
+    }
+    ;(globalThis as Record<string, unknown>).localStorage = localStorageMock
+    try {
+      // 页面 1：观察 b 运行 → 完成（记入并持久化）
+      reconcilePersistedAttention(list([session({ id: 'b', running: true })], 'a'))
+      reconcilePersistedAttention(list([session({ id: 'b', running: false })], 'a'))
+      expect(isPersistedUnread('b')).toBe(true)
+      expect(store.size).toBeGreaterThan(0)
+
+      // 页面 2：全新模块实例（模拟刷新），从 localStorage 恢复
+      vi.resetModules()
+      const fresh = await import('../src/client/workbench/session-monitor.ts')
+      expect(fresh.isPersistedUnread('b')).toBe(true)
+      // 恢复后 isUnread 依然成立（壳层 completed 是 undefined）
+      expect(fresh.isUnread({ id: 'b' } as never, undefined, new Set())).toBe(true)
+    } finally {
+      ;(globalThis as Record<string, unknown>).localStorage = undefined
+    }
+  })
+
+  it('clears on explicit ack (open / mark-read) and on re-run or becoming current', () => {
+    reconcilePersistedAttention(list([session({ id: 'b', running: true })], 'a'))
+    reconcilePersistedAttention(list([session({ id: 'b', running: false })], 'a'))
+    expect(isPersistedUnread('b')).toBe(true)
+
+    // 显式记认（打开会话 / 全部标为已读）
+    ackSession('b')
+    expect(isPersistedUnread('b')).toBe(false)
+    reconcilePersistedAttention(list([session({ id: 'b', running: false })], 'a'))
+    reconcilePersistedAttention(list([session({ id: 'c', running: true })], 'a'))
+    reconcilePersistedAttention(list([session({ id: 'c', running: false })], 'a'))
+    expect(isPersistedUnread('c')).toBe(true)
+    ackMany(['c'])
+    expect(isPersistedUnread('c')).toBe(false)
+
+    // 再次运行清除
+    reconcilePersistedAttention(list([session({ id: 'd', running: true })], 'a'))
+    reconcilePersistedAttention(list([session({ id: 'd', running: false })], 'a'))
+    expect(isPersistedUnread('d')).toBe(true)
+    reconcilePersistedAttention(list([session({ id: 'd', running: true })], 'a'))
+    expect(isPersistedUnread('d')).toBe(false)
+
+    // 成为当前会话（被查看）清除
+    reconcilePersistedAttention(list([session({ id: 'e', running: true })], 'a'))
+    reconcilePersistedAttention(list([session({ id: 'e', running: false })], 'a'))
+    expect(isPersistedUnread('e')).toBe(true)
+    reconcilePersistedAttention(list([session({ id: 'e', running: false })], 'e'))
+    expect(isPersistedUnread('e')).toBe(false)
+  })
+
+  it('backs up the shell completed flag into the persisted record and drops vanished sessions', () => {
+    // 壳层本页武装 completed → 持久化兜底
+    reconcilePersistedAttention(list([session({ id: 'c', completed: true })], 'a'))
+    expect(isPersistedUnread('c')).toBe(true)
+    // 会话从列表消失 → 清理残留
+    reconcilePersistedAttention(list([session({ id: 'x' })], 'a'))
+    expect(isPersistedUnread('c')).toBe(false)
   })
 })


### PR DESCRIPTION
## What（修复内容）

PR #15（全局会话监控面板 + 提示音系统）合并后的两项缺陷修复：

1. **「完成未查看」提醒跨页面持久化**：壳层 dsh 的 `completed` 提醒是**页面会话期内存态**——刷新/重开页面后，已 idle 会话的完成提醒不会重新武装，导致「需要你注意」列表少显示实际需要注意的会话（例如两条会话完成、列表只显示一条）。插件改为在 localStorage 持久化自己的完成记认（running→idle 边沿跨页面检测 + 壳层 completed 兜底），打开 / 全部标为已读 / 再次运行 / 成为当前会话时清除。

2. **提示音自动提醒失效**：`Workbench` 每次响铃都新建 `AudioContext`——新上下文默认 `suspended`、`resume()` 需用户手势（浏览器自动播放策略），且 Chrome 上下文数量上限约 6 个，循环提醒（默认每 10s）下约 1 分钟触顶后被 `catch` 静默吞掉，导致「首次出现」与「循环定时」都不出声。改为**模块级共享复用同一个 AudioContext**（`sharedBeepRef`）+ 首次用户手势解锁，恢复 V1 等效的稳定出声行为。

## Why（背景）

- 「需要你注意」是查看全局会话状态的核心入口，提醒丢失会造成漏看；提示音是注意项出现时的主动提醒，二者失效直接影响功能价值。
- 根因均经真实 SessionManager 复现测试确认，并新增 4 个持久化记认用例（完成边沿武装 / 跨页面刷新恢复 / 打开与再次运行清除 / 壳层 completed 兜底）。

## 改动清单

- `src/client/workbench/session-monitor.ts`：持久化完成记认（localStorage）+ `reconcilePersistedAttention` + `isUnread` 双重来源
- `src/client/workbench/useSessionMonitor.ts`：`useAttentionPersist` / `usePersistVersion` 接线 + 共享 AudioContext（`sharedBeepRef`）+ 首次手势解锁
- `src/client/workbench/Workbench.tsx`：挂载 `useAttentionPersist`；`playSound` 改用 `sharedBeepRef`
- `src/client/workbench/SessionsPanel.tsx`：订阅持久化记认版本（配合上游 5c9c5a7 图标化 toggle）
- `tests/session-monitor.spec.ts`：新增 4 个持久化记认用例

## 给维护者的注意事项

- 本 PR **不含构建产物**（lib/），合并时请执行 `bash devops/build.sh` 重新构建。
- 本地已验证：`pnpm build` 编译通过；`pnpm test` 584 用例全部通过。
