### PR TITLE
feat(workbench): 会话渲染增强 — 回答尾部渲染 SVG 卡片（含下载 HTML/图片/复制代码菜单）

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,9 @@ import { installEditorRefClient } from './workbench/editor-ref-client.ts'
 import { Workbench } from './workbench/Workbench.tsx'
 import type { WorkbenchInjected } from './workbench/types.ts'
 import { en, NS, zh } from './locales.ts'
+import { selectSvgTailGated } from './workbench/svg-render-settings.ts'
+import { svgRenderEn, svgRenderZh } from './workbench/svg-render-locales.ts'
+import { SvgTailView } from './workbench/SvgTailView.tsx'
 
 export const inject = ['slots', 'locale', 'inputTriggers', 'sessions']
 
@@ -20,18 +23,22 @@ function registerWorkbenchLocale(locale: {
   dicts?: Map<string, Map<string, Record<string, string>>>
   register: (ns: string, dicts: unknown) => unknown
 }): () => void {
+  // SVG 渲染翻译外移到独立模块（svg-render-locales.ts），注册时运行时合并进
+  // workbench 命名空间，避免逐行插入 locales.ts（缩小上游合并冲突面）。
+  const fullZh = { ...zh, ...svgRenderZh }
+  const fullEn = { ...en, ...svgRenderEn }
   const table = locale.dicts?.get(NS)
   if (table !== undefined && (table.has('zh') || table.has('en'))) {
     const zhDict = table.get('zh')
     const enDict = table.get('en')
-    if (zhDict !== undefined) Object.assign(zhDict, zh)
-    else table.set('zh', { ...zh })
-    if (enDict !== undefined) Object.assign(enDict, en)
-    else table.set('en', { ...en })
+    if (zhDict !== undefined) Object.assign(zhDict, fullZh)
+    else table.set('zh', { ...fullZh })
+    if (enDict !== undefined) Object.assign(enDict, fullEn)
+    else table.set('en', { ...fullEn })
     return () => {}
   }
   try {
-    return locale.register(NS, { zh, en })
+    return locale.register(NS, { zh: fullZh, en: fullEn })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     if (!/already has locale/.test(message)) throw error
@@ -39,8 +46,8 @@ function registerWorkbenchLocale(locale: {
     if (again === undefined) throw error
     const zhDict = again.get('zh')
     const enDict = again.get('en')
-    if (zhDict !== undefined) Object.assign(zhDict, zh)
-    if (enDict !== undefined) Object.assign(enDict, en)
+    if (zhDict !== undefined) Object.assign(zhDict, fullZh)
+    if (enDict !== undefined) Object.assign(enDict, fullEn)
     return () => {}
   }
 }
@@ -100,4 +107,13 @@ export function apply(ctx: ClientContext): void {
       }, GitToolRow)
     }
   })
+
+  // 会话渲染增强：回答尾部渲染标准 SVG（conversation.chat.turnTail 扩展点）。
+  // select 内部按设置开关门控：关闭时返回 null（不匹配、不渲染），与无 SVG 时不渲染的行为一致。
+  ctx.slots.inject('conversation.chat.turnTail', () => ctx.slots.register({
+    name: 'conversation.chat.turnTail',
+    id: 'workbench-svg-tail',
+    locale: NS,
+    select: selectSvgTailGated,
+  }, SvgTailView))
 }

--- a/src/client/workbench/SettingsPanel.module.css
+++ b/src/client/workbench/SettingsPanel.module.css
@@ -217,3 +217,33 @@
   min-width: 0;
   margin-top: 6px;
 }
+
+/* 会话渲染增强：tip 说明 + 合法 SVG 示例代码块 */
+.svgRenderTip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  padding: 4px 8px 8px;
+}
+
+.svgRenderTipText {
+  color: var(--dsw-alias-label-secondary);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.svgRenderTipCode {
+  display: block;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 6px;
+  background: var(--dsw-alias-bg-layer-1);
+  color: var(--dsw-alias-label-primary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/src/client/workbench/SettingsPanel.tsx
+++ b/src/client/workbench/SettingsPanel.tsx
@@ -6,7 +6,8 @@
  *
  * 布局仿照 Git 侧栏 CHANGES / GRAPH 的折叠分区（sectionHead + 可折叠 paneBody）：
  * ① 声音与提醒 —— 提示音总闸、铃声选择、循环提醒与间隔；
- * ② 插件命令 —— 复用 SlashPanel 的 SettingsSection（内置 / 自定义斜杠命令管理）。
+ * ② 插件命令 —— 复用 SlashPanel 的 SettingsSection（内置 / 自定义斜杠命令管理）；
+ * ③ 会话渲染增强 —— 会话中 SVG 标签回答的渲染开关。
  */
 import { useRef, useState, useSyncExternalStore } from 'react'
 import {
@@ -15,6 +16,8 @@ import {
 } from './reminder-settings.ts'
 import type { Translate } from './types.ts'
 import { useBeepOn, useLoopReminder, useReminderInterval } from './useSessionMonitor.ts'
+import { useSvgRenderOn } from './svg-render-settings.ts'
+import { SVG_RENDER_EXAMPLE } from './svg-tail.ts'
 import { IconChevron } from './icons.tsx'
 import { SoundSettings } from './SoundSettings.tsx'
 import { SettingsSection } from '../ultra-slash/SlashPanel.tsx'
@@ -22,9 +25,11 @@ import { getSlashCache, getSlashI18n, subscribeSlashI18n } from '../ultra-slash/
 import {
   DEFAULT_SETTINGS_COMMANDS_OPEN,
   DEFAULT_SETTINGS_SOUND_OPEN,
+  DEFAULT_SETTINGS_SVG_RENDER_OPEN,
   readBoolFlag,
   SETTINGS_COMMANDS_OPEN_KEY,
   SETTINGS_SOUND_OPEN_KEY,
+  SETTINGS_SVG_RENDER_OPEN_KEY,
   writeBoolFlag,
 } from './ui-flags.ts'
 import css from './SettingsPanel.module.css'
@@ -56,6 +61,7 @@ export function SettingsPanel({ t }: { t: Translate }) {
   const [beepOn, setBeepOn] = useBeepOn()
   const [loopOn, setLoopOn] = useLoopReminder()
   const [intervalSec, setIntervalSec] = useReminderInterval()
+  const [svgRenderOn, setSvgRenderOn] = useSvgRenderOn()
   // 循环提醒生效 = 提示音总闸开启 且 循环提醒子开关开启（提示音关闭时联动失效，UI 与行为一致）
   const loopActive = beepOn && loopOn
   // 间隔输入草稿：键入过程中不写偏好，失焦 / Enter 才提交，非法输入回退
@@ -80,6 +86,7 @@ export function SettingsPanel({ t }: { t: Translate }) {
 
   const [soundOpen, setSoundOpen] = useState(() => readBoolFlag(SETTINGS_SOUND_OPEN_KEY, DEFAULT_SETTINGS_SOUND_OPEN))
   const [commandsOpen, setCommandsOpen] = useState(() => readBoolFlag(SETTINGS_COMMANDS_OPEN_KEY, DEFAULT_SETTINGS_COMMANDS_OPEN))
+  const [svgRenderOpen, setSvgRenderOpen] = useState(() => readBoolFlag(SETTINGS_SVG_RENDER_OPEN_KEY, DEFAULT_SETTINGS_SVG_RENDER_OPEN))
   const toggleSound = (): void => {
     setSoundOpen((open) => {
       writeBoolFlag(SETTINGS_SOUND_OPEN_KEY, !open)
@@ -89,6 +96,12 @@ export function SettingsPanel({ t }: { t: Translate }) {
   const toggleCommands = (): void => {
     setCommandsOpen((open) => {
       writeBoolFlag(SETTINGS_COMMANDS_OPEN_KEY, !open)
+      return !open
+    })
+  }
+  const toggleSvgRender = (): void => {
+    setSvgRenderOpen((open) => {
+      writeBoolFlag(SETTINGS_SVG_RENDER_OPEN_KEY, !open)
       return !open
     })
   }
@@ -174,6 +187,32 @@ export function SettingsPanel({ t }: { t: Translate }) {
             <div className={css.paneBody}>
               {/* embedded：隐藏 SettingsSection 自带标题，避免与分区头重复 */}
               <SettingsSection embedded t={slashI18n.t} locale={slashI18n.locale} cache={getSlashCache()} />
+            </div>
+          ) : null}
+        </section>
+
+        <section className={css.pane} data-open={svgRenderOpen || undefined}>
+          <div className={css.sectionHead}>
+            <button type="button" className={css.sectionToggle} aria-expanded={svgRenderOpen} onClick={toggleSvgRender}>
+              <IconChevron open={svgRenderOpen} />
+              <span className={css.sectionTitle}>{t('settings.section.svgRender')}</span>
+            </button>
+          </div>
+          {svgRenderOpen ? (
+            <div className={css.paneBody}>
+              <div className={css.settingRow}>
+                <span className={css.settingLabel}>{t('settings.svgRenderLabel')}</span>
+                <SettingsSwitch
+                  on={svgRenderOn}
+                  label={svgRenderOn ? t('settings.svgRenderOff') : t('settings.svgRenderOn')}
+                  title={svgRenderOn ? t('settings.svgRenderOnHint') : t('settings.svgRenderOffHint')}
+                  onToggle={setSvgRenderOn}
+                />
+              </div>
+              <div className={css.svgRenderTip}>
+                <span className={css.svgRenderTipText}>{t('settings.svgRenderTip')}</span>
+                <code className={css.svgRenderTipCode}>{SVG_RENDER_EXAMPLE}</code>
+              </div>
             </div>
           ) : null}
         </section>

--- a/src/client/workbench/SvgTailView.module.css
+++ b/src/client/workbench/SvgTailView.module.css
@@ -1,0 +1,67 @@
+/* 会话渲染增强 · SVG 卡片（能力移植自 svg-viewer 的主题适配样式） */
+.tail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 10px 0 4px;
+}
+
+/* 卡片外层：为右上角工具栏与浮动提示提供定位上下文 */
+.cardWrap {
+  position: relative;
+  min-width: 0;
+}
+
+.card {
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 10px;
+  padding: 12px;
+  background: var(--dsw-alias-bg-layer-1);
+  overflow-x: auto;
+}
+
+.card svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+/* 右上角 "..." 工具栏：悬浮在卡片右上外缘，不遮挡 SVG 内容 */
+.cardToolbar {
+  position: absolute;
+  top: -10px;
+  right: 8px;
+  z-index: 2;
+}
+
+.moreBtn {
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 6px;
+  background: var(--dsw-alias-bg-layer-1);
+  color: var(--dsw-alias-label-secondary);
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+.moreBtn:hover {
+  background: var(--dsw-alias-interactive-bg-hover);
+  color: var(--dsw-alias-label-primary);
+}
+
+/* 复制成功/失败浮动提示（卡片右上角下方） */
+.notice {
+  position: absolute;
+  top: 14px;
+  right: 8px;
+  z-index: 3;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--dsw-alias-state-business-primary, #7aa2ff);
+  color: var(--dsw-alias-label-primary-foreground, #fff);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+}

--- a/src/client/workbench/SvgTailView.tsx
+++ b/src/client/workbench/SvgTailView.tsx
@@ -1,0 +1,123 @@
+/**
+ * 会话渲染增强 · SVG 回答可视化视图（conversation.chat.turnTail 卡片渲染）。
+ *
+ * select（svg-render-settings.ts 的 selectSvgTailGated）返回匹配到的 SVG 列表，
+ * 经 props.matched 注入；本视图对每个标准 SVG 渲染一张卡片（dangerouslySetInnerHTML
+ * 注入，注入前已做最小安全清洗）。开关关闭时 select 返回 null，本视图不渲染。
+ *
+ * 卡片右上角提供 "..." 菜单（IconMore + ContextMenu）：
+ *  - 下载为 HTML（svgToHtml + downloadBlob）
+ *  - 下载为图片（svgToPng + downloadBlob）
+ *  - 复制代码（copyText）
+ */
+import { useState, type MouseEvent as ReactMouseEvent, type ReactElement } from 'react'
+import type { PropsLocale } from '@deepseek-ai/dsh-client-ui-slots'
+import { sanitizeSvg } from './svg-tail.ts'
+import {
+  copyText,
+  downloadBlob,
+  svgToHtml,
+  svgToPng,
+} from './svg-card-actions.ts'
+import { IconButton } from './IconButton.tsx'
+import { ContextMenu, type ContextMenuEntry } from './ContextMenu.tsx'
+import { IconCopy, IconMore } from './icons.tsx'
+import css from './SvgTailView.module.css'
+
+export interface SvgTailViewProps extends PropsLocale<'workbench'> {
+  /** turnTail select 匹配结果：标准 SVG 字符串数组（或 null/undefined）。 */
+  matched?: unknown
+}
+
+interface MenuPos {
+  x: number
+  y: number
+}
+
+export function SvgTailView({ matched, t }: SvgTailViewProps): ReactElement | null {
+  const svgs = Array.isArray(matched) ? matched.filter((s): s is string => typeof s === 'string') : []
+  if (svgs.length === 0) return null
+  return (
+    <div className={css.tail}>
+      {svgs.map((svg, index) => {
+        const clean = sanitizeSvg(svg)
+        if (clean === null) return null
+        return <SvgCard key={index} index={index} svg={clean} t={t} />
+      })}
+    </div>
+  )
+}
+
+function SvgCard({ index, svg, t }: { index: number; svg: string; t: SvgTailViewProps['t'] }): ReactElement {
+  const [menuPos, setMenuPos] = useState<MenuPos | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const showNotice = (message: string): void => {
+    setNotice(message)
+    window.setTimeout(() => { setNotice(null) }, 1800)
+  }
+
+  const openMenu = (event: ReactMouseEvent<HTMLButtonElement>): void => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    setMenuPos({ x: rect.right - 4, y: rect.bottom + 4 })
+  }
+
+  const items: ContextMenuEntry[] = [
+    {
+      kind: 'item',
+      id: 'download-html',
+      label: t('svgCard.downloadHtml'),
+      onClick: () => {
+        downloadBlob(new Blob([svgToHtml(svg)], { type: 'text/html;charset=utf-8' }), `svg-${index + 1}.html`)
+      },
+    },
+    {
+      kind: 'item',
+      id: 'download-image',
+      label: t('svgCard.downloadImage'),
+      onClick: () => {
+        svgToPng(svg).then((blob) => {
+          downloadBlob(blob, `svg-${index + 1}.png`)
+        }).catch(() => {
+          showNotice(t('svgCard.downloadImageFailed'))
+        })
+      },
+    },
+    {
+      kind: 'item',
+      id: 'copy-code',
+      label: t('svgCard.copyCode'),
+      icon: <IconCopy />,
+      onClick: () => {
+        copyText(svg).then((ok) => {
+          showNotice(ok ? t('svgCard.copied') : t('svgCard.copyFailed'))
+        })
+      },
+    },
+  ]
+
+  return (
+    <>
+      <div className={css.cardWrap}>
+        <div className={css.card} dangerouslySetInnerHTML={{ __html: svg }} />
+        <div className={css.cardToolbar}>
+          <IconButton dense label={t('svgCard.menu')} className={css.moreBtn} onClick={openMenu}>
+            <IconMore />
+          </IconButton>
+        </div>
+        {notice !== null ? (
+          <div className={css.notice} role="status">{notice}</div>
+        ) : null}
+      </div>
+      {menuPos !== null ? (
+        <ContextMenu
+          x={menuPos.x}
+          y={menuPos.y}
+          items={items}
+          ariaLabel={t('svgCard.menu')}
+          onClose={() => { setMenuPos(null) }}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/src/client/workbench/svg-card-actions.ts
+++ b/src/client/workbench/svg-card-actions.ts
@@ -1,0 +1,125 @@
+/**
+ * 会话渲染增强 · SVG 卡片操作（纯逻辑，无 React 依赖，可独立单测）。
+ *
+ * 为卡片右上角 "..." 菜单提供三个能力：
+ *  1. svgToHtml / downloadBlob —— 下载为独立 HTML 文档；
+ *  2. svgToPng / downloadBlob  —— 下载为 PNG 图片（canvas 栅格化，白底）；
+ *  3. copyText                  —— 复制 SVG 代码到剪贴板（clipboard + 降级）。
+ */
+
+/** 把 SVG 包成可独立打开的 HTML 文档（居中、白底、自适应宽度）。 */
+export function svgToHtml(svg: string): string {
+  const style = [
+    'body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#fff}',
+    'svg{max-width:100%;height:auto}',
+  ].join('')
+  return [
+    '<!doctype html>',
+    '<html lang="zh-CN">',
+    '<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>SVG</title>',
+    `<style>${style}</style>`,
+    '</head>',
+    '<body>',
+    svg,
+    '</body>',
+    '</html>',
+  ].join('\n')
+}
+
+/** 触发浏览器下载一个 Blob。 */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  // 延迟回收，避免部分浏览器在点击前就失效
+  setTimeout(() => { URL.revokeObjectURL(url) }, 1000)
+}
+
+/** 解析 SVG 的渲染尺寸：viewBox 优先，其次 width/height，缺省 300×150。 */
+export function svgViewSize(svg: string): { width: number; height: number } {
+  let root: Element | null = null
+  try {
+    const doc = new DOMParser().parseFromString(svg, 'application/xml')
+    root = doc.documentElement
+  } catch { /* fall through to defaults */ }
+  const attr = (name: string): string | undefined => root?.getAttribute(name) ?? undefined
+  const viewBox = attr('viewBox')
+  if (viewBox !== undefined) {
+    const parts = viewBox.trim().split(/[\s,]+/).map(Number)
+    if (parts.length === 4 && parts.every((n) => Number.isFinite(n)) && parts[2] > 0 && parts[3] > 0) {
+      return { width: parts[2], height: parts[3] }
+    }
+  }
+  const w = Number.parseFloat(attr('width') ?? '')
+  const h = Number.parseFloat(attr('height') ?? '')
+  if (Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0) {
+    return { width: w, height: h }
+  }
+  return { width: 300, height: 150 }
+}
+
+/**
+ * SVG → PNG Blob（canvas 栅格化，scale 放大倍数，白底）。
+ * 注意：SVG 内若引用外部资源（<image href> 外链等）受 canvas 污染策略影响，
+ * 本插件渲染的都是 agent 回答中的内联 SVG，通常无此问题。
+ */
+export function svgToPng(svg: string, scale = 2): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const img = new Image()
+    img.onload = () => {
+      try {
+        const { width, height } = svgViewSize(svg)
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.max(1, Math.round(width * scale))
+        canvas.height = Math.max(1, Math.round(height * scale))
+        const ctx = canvas.getContext('2d')
+        if (ctx === null) throw new Error('canvas 2d context unavailable')
+        ctx.fillStyle = '#ffffff'
+        ctx.fillRect(0, 0, canvas.width, canvas.height)
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+        canvas.toBlob((out) => {
+          if (out !== null) resolve(out)
+          else reject(new Error('canvas.toBlob returned null'))
+        }, 'image/png')
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        URL.revokeObjectURL(url)
+      }
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('SVG image failed to load'))
+    }
+    img.src = url
+  })
+}
+
+/** 复制文本到剪贴板：优先 Clipboard API，失败降级到 execCommand。 */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch { /* fall through to legacy path */ }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.style.position = 'fixed'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}

--- a/src/client/workbench/svg-render-locales.ts
+++ b/src/client/workbench/svg-render-locales.ts
@@ -1,0 +1,43 @@
+/**
+ * 会话渲染增强 · 翻译 key（中英文）。
+ *
+ * 按 GIT-MERGE-SOP L1「翻译外移」策略独立成模块：locales.ts 是上游合并最高频
+ * 冲突文件，新二开翻译不再逐行插入其中，而是在 index.ts 注册时运行时合并进
+ * workbench 命名空间，缩小合并冲突面。
+ */
+
+export const svgRenderZh = {
+  'settings.section.svgRender': '会话渲染增强',
+  'settings.svgRenderLabel': '渲染会话中的 SVG 标签',
+  'settings.svgRenderOn': '开启SVG渲染',
+  'settings.svgRenderOff': '关闭SVG渲染',
+  'settings.svgRenderOnHint': 'SVG 渲染已开启：agent 回复中的 SVG 标签会在该条回答底部渲染为图片（点击关闭）',
+  'settings.svgRenderOffHint': 'SVG 渲染已关闭：agent 回复中的 SVG 标签仅以代码形式显示（点击开启）',
+  'settings.svgRenderTip': '开启后，agent 回复中以 ```svg 围栏代码块或完整 <svg>…</svg> 标签输出的内容，会在该条回答底部渲染为 SVG 图片。例如：',
+  // 卡片右上角 "..." 菜单
+  'svgCard.menu': 'SVG 操作',
+  'svgCard.downloadHtml': '下载为 HTML',
+  'svgCard.downloadImage': '下载为图片',
+  'svgCard.copyCode': '复制代码',
+  'svgCard.copied': '已复制',
+  'svgCard.copyFailed': '复制失败',
+  'svgCard.downloadImageFailed': '导出图片失败',
+} satisfies Record<string, string>
+
+export const svgRenderEn = {
+  'settings.section.svgRender': 'Session rendering',
+  'settings.svgRenderLabel': 'Render SVG tags in session',
+  'settings.svgRenderOn': 'Enable SVG rendering',
+  'settings.svgRenderOff': 'Disable SVG rendering',
+  'settings.svgRenderOnHint': 'SVG rendering is on: SVG tags in agent replies render as images at the bottom of that reply (click to turn off)',
+  'settings.svgRenderOffHint': 'SVG rendering is off: SVG tags in agent replies show as code only (click to turn on)',
+  'settings.svgRenderTip': 'When enabled, SVG content the agent outputs as a ```svg fenced block or a complete <svg>…</svg> tag renders as an image at the bottom of that reply. For example:',
+  // Card "..." menu
+  'svgCard.menu': 'SVG actions',
+  'svgCard.downloadHtml': 'Download as HTML',
+  'svgCard.downloadImage': 'Download as image',
+  'svgCard.copyCode': 'Copy code',
+  'svgCard.copied': 'Copied',
+  'svgCard.copyFailed': 'Copy failed',
+  'svgCard.downloadImageFailed': 'Image export failed',
+} satisfies Record<string, string>

--- a/src/client/workbench/svg-render-settings.ts
+++ b/src/client/workbench/svg-render-settings.ts
@@ -1,0 +1,54 @@
+/**
+ * 会话渲染增强 · 开关偏好（页面级配置，localStorage 持久化，刷新不丢）。
+ *
+ * 与 svg-tail.ts 的纯提取逻辑分离：本模块只负责「是否开启会话中 SVG 标签渲染」
+ * 这一个开关的读取 / 写入 / 订阅，并基于该开关组装 turnTail 链的 select 路由
+ * （关闭时不匹配，返回 null——与 svg-viewer 无 SVG 时不渲染的行为一致）。
+ */
+import { useEffect, useState } from 'react'
+import { readBoolFlag, writeBoolFlag } from './ui-flags.ts'
+import { selectSvgTail } from './svg-tail.ts'
+
+export const SVG_RENDER_ON_KEY = 'dsh-workbench-svg-render-on'
+
+/** 出厂默认：开启（能力移植自 svg-viewer，保持其默认渲染行为）。 */
+export const DEFAULT_SVG_RENDER_ON = true
+
+let svgRenderOn = readBoolFlag(SVG_RENDER_ON_KEY, DEFAULT_SVG_RENDER_ON)
+const listeners = new Set<(on: boolean) => void>()
+
+export function getSvgRenderOn(): boolean {
+  return svgRenderOn
+}
+
+export function setSvgRenderOn(value: boolean): void {
+  if (svgRenderOn === value) return
+  svgRenderOn = value
+  writeBoolFlag(SVG_RENDER_ON_KEY, value)
+  for (const fn of listeners) fn(value)
+}
+
+/** React useSyncExternalStore 风格订阅（模块级单例，供设置面板开关联动）。 */
+export function subscribeSvgRenderOn(fn: (on: boolean) => void): () => void {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}
+
+/** 设置面板开关 hook：读当前值 + 订阅变化 + 写回偏好。 */
+export function useSvgRenderOn(): [boolean, (on: boolean) => void] {
+  const [on, setOn] = useState(getSvgRenderOn)
+  useEffect(() => subscribeSvgRenderOn(setOn), [])
+  return [on, setSvgRenderOn]
+}
+
+/** turnTail 链 select 路由：开关关闭时不匹配（返回 null，不渲染）。 */
+export function selectSvgTailGated(owner: unknown): string[] | null {
+  return getSvgRenderOn() ? selectSvgTail(owner) : null
+}
+
+/** 测试辅助：复位到出厂默认并清空持久化。 */
+export function resetSvgRenderOn(): void {
+  svgRenderOn = DEFAULT_SVG_RENDER_ON
+  writeBoolFlag(SVG_RENDER_ON_KEY, svgRenderOn)
+  for (const fn of listeners) fn(svgRenderOn)
+}

--- a/src/client/workbench/svg-tail.ts
+++ b/src/client/workbench/svg-tail.ts
@@ -1,0 +1,107 @@
+/**
+ * 会话渲染增强 · SVG 回答可视化（能力移植自 wake-dsh-plu-svg-viewer 动态插件）
+ *
+ * 原则：只认标准规范格式，逻辑极简，稳定优先。
+ *  1. 合并该 turn 全部 text block 后统一提取（流式输出会把回答切成多个 block）；
+ *  2. 标准校验 isStandardSvg：完整 <svg …>…</svg>（<svg 开头 + </svg> 结尾 + 内部至少一个元素）；
+ *  3. 防跨行垃圾匹配：SVG 内部不得再出现 <svg 字样。正文表格/字面量里
+ *     “<svg>…</svg>” 这类文字会从 <svg> 一直吃到别处的 </svg>，产生以 <svg
+ *     开头、</svg> 结尾但内部混着 <svg 字样的垃圾串，此校验将其拒绝；
+ *  4. 最小安全清洗：script / foreignObject / on* 事件属性；
+ *  5. 支持两种标准写法：```svg 围栏内、或正文中独立的完整 <svg> 标签。
+ *
+ * 本文件为纯逻辑（无 React / 无 DOM），可独立单测。
+ */
+
+/** 标准校验：完整 <svg>…</svg>，内部至少一个元素，且内部不再嵌套 <svg */
+export function isStandardSvg(raw: string): boolean {
+  const t = String(raw).trim()
+  if (!/^<svg[\s>]/i.test(t) || !/<\/svg\s*>$/i.test(t)) return false
+  const inner = t.replace(/^<svg[^>]*>/i, '').replace(/<\/svg\s*>$/i, '')
+  if (inner.indexOf('<svg') !== -1) return false
+  return /<[a-zA-Z]/.test(inner)
+}
+
+/** 最小安全清洗：移除可执行内容载体与事件属性，其余原样保留 */
+export function sanitizeSvg(raw: string): string | null {
+  let s = String(raw)
+  s = s.replace(/<script[\s\S]*?<\/script\s*>/gi, '')
+  s = s.replace(/<foreignObject[\s\S]*?<\/foreignObject\s*>/gi, '')
+  s = s.replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*')/gi, '')
+  return isStandardSvg(s) ? s.trim() : null
+}
+
+/** 从一段文本提取所有标准 SVG：围栏内优先，正文中完整的 <svg> 标签其次，去重 */
+export function extractSvgs(text: string): string[] {
+  const out: string[] = []
+  const seen: Record<string, boolean> = {}
+  const fenceRe = /```svg\s*\n?([\s\S]*?)```/g
+  let m: RegExpExecArray | null
+  while ((m = fenceRe.exec(text)) !== null) {
+    const body = m[1].trim()
+    if (isStandardSvg(body) && !Object.prototype.hasOwnProperty.call(seen, body)) {
+      seen[body] = true
+      out.push(body)
+    }
+  }
+  const rest = text.replace(fenceRe, '')
+  const rawRe = /<svg[\s>][\s\S]*?<\/svg\s*>/gi
+  let r: RegExpExecArray | null
+  while ((r = rawRe.exec(rest)) !== null) {
+    const svg = r[0].trim()
+    if (isStandardSvg(svg) && !Object.prototype.hasOwnProperty.call(seen, svg)) {
+      seen[svg] = true
+      out.push(svg)
+    }
+  }
+  return out
+}
+
+/** turnTail 链 select 入参的最小结构（owner.turn.data.get('turn-tail')） */
+export interface TurnTailOwner {
+  turn: {
+    data: {
+      get(key: string): unknown
+    }
+  }
+}
+
+interface TurnTailClosing {
+  closing?: {
+    blocks?: Array<{ kind?: string; text?: string }>
+  }
+}
+
+/** turnTail 链路由：合并全部 text block 后提取，仅当含标准 SVG 时匹配 */
+export function selectSvgTail(owner: unknown): string[] | null {
+  try {
+    const tail = (owner as TurnTailOwner | undefined)?.turn?.data?.get('turn-tail') as
+      | TurnTailClosing
+      | undefined
+    const closing = tail?.closing
+    if (!closing) return null
+    let full = ''
+    const blocks = closing.blocks || []
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+      if (block && block.kind === 'text' && typeof block.text === 'string') {
+        full += block.text + '\n'
+      }
+    }
+    const svgs = extractSvgs(full)
+    return svgs.length === 0 ? null : svgs
+  } catch (err) {
+    console.error('svg-tail select failed', err)
+    return null
+  }
+}
+
+/**
+ * 设置面板 tip 中展示的合法简单 SVG 示例：符合 isStandardSvg 标准，
+ * 用户据此知道 agent 回复怎样的标签会在会话底部被渲染为 SVG。
+ */
+export const SVG_RENDER_EXAMPLE =
+  '<svg width="120" height="60" xmlns="http://www.w3.org/2000/svg">' +
+  '<rect x="10" y="10" width="100" height="40" rx="8" fill="#4c8dff"/>' +
+  '<text x="60" y="38" font-size="16" fill="#ffffff" text-anchor="middle">Hello</text>' +
+  '</svg>'

--- a/src/client/workbench/ui-flags.ts
+++ b/src/client/workbench/ui-flags.ts
@@ -21,6 +21,7 @@ export const TERM_AI_OPEN_KEY = 'dsh-workbench-term-ai-open'
 export const TERM_AI_SETTINGS_OPEN_KEY = 'dsh-workbench-term-ai-settings-open'
 export const SETTINGS_SOUND_OPEN_KEY = 'dsh-workbench-settings-sound-open'
 export const SETTINGS_COMMANDS_OPEN_KEY = 'dsh-workbench-settings-commands-open'
+export const SETTINGS_SVG_RENDER_OPEN_KEY = 'dsh-workbench-settings-svg-render-open'
 
 /** Compact GRAPH (message-only rows) is the factory default. */
 export const DEFAULT_GRAPH_COMPACT = true
@@ -33,3 +34,4 @@ export const DEFAULT_TERM_AI_SETTINGS_OPEN = false
 /** 设置面板折叠分区默认全部展开（与 git CHANGES 折叠交互一致）。 */
 export const DEFAULT_SETTINGS_SOUND_OPEN = true
 export const DEFAULT_SETTINGS_COMMANDS_OPEN = true
+export const DEFAULT_SETTINGS_SVG_RENDER_OPEN = true

--- a/tests/svg-card-actions.spec.ts
+++ b/tests/svg-card-actions.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  copyText,
+  downloadBlob,
+  svgToHtml,
+  svgViewSize,
+} from '../src/client/workbench/svg-card-actions.ts'
+
+const SIMPLE_SVG =
+  '<svg width="120" height="60" xmlns="http://www.w3.org/2000/svg"><rect x="10" y="10" width="100" height="40" rx="8" fill="#4c8dff"/><text x="60" y="38" font-size="16" fill="#ffffff" text-anchor="middle">Hello</text></svg>'
+
+describe('svgToHtml', () => {
+  it('wraps the svg in a standalone html document', () => {
+    const html = svgToHtml(SIMPLE_SVG)
+    expect(html).toContain('<!doctype html>')
+    expect(html).toContain('<html')
+    expect(html).toContain('</html>')
+    expect(html).toContain(SIMPLE_SVG)
+  })
+})
+
+describe('svgViewSize', () => {
+  it('prefers viewBox when present', () => {
+    const svg = '<svg viewBox="0 0 200 100" width="10" height="10"><rect/></svg>'
+    expect(svgViewSize(svg)).toEqual({ width: 200, height: 100 })
+  })
+
+  it('falls back to width/height attributes', () => {
+    expect(svgViewSize(SIMPLE_SVG)).toEqual({ width: 120, height: 60 })
+  })
+
+  it('returns defaults when no size info exists', () => {
+    expect(svgViewSize('<svg><circle r="5"/></svg>')).toEqual({ width: 300, height: 150 })
+  })
+
+  it('does not throw on invalid svg', () => {
+    expect(svgViewSize('not an svg at all')).toEqual({ width: 300, height: 150 })
+  })
+})
+
+describe('downloadBlob', () => {
+  it('creates an anchor, clicks it, and cleans up', () => {
+    const click = vi.fn()
+    const remove = vi.fn()
+    const originalCreate = document.createElement.bind(document)
+    const append = vi.spyOn(document.body, 'appendChild').mockImplementation(() => document.createElement('div'))
+    const anchor = { href: '', download: '', click, remove } as unknown as HTMLAnchorElement
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return anchor as unknown as HTMLElement
+      return originalCreate(tag)
+    })
+    try {
+      downloadBlob(new Blob(['x'], { type: 'text/plain' }), 't.txt')
+      expect(click).toHaveBeenCalledTimes(1)
+      expect(anchor.download).toBe('t.txt')
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+})
+
+describe('copyText', () => {
+  it('uses the clipboard API when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    await expect(copyText('hello')).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('falls back to execCommand when clipboard is unavailable', async () => {
+    Object.assign(navigator, { clipboard: undefined })
+    // jsdom 未实现 execCommand：先补一个，再 spy 验证调用
+    const exec = vi.fn().mockReturnValue(true)
+    Object.assign(document, { execCommand: exec })
+    await expect(copyText('hello')).resolves.toBe(true)
+    expect(exec).toHaveBeenCalledWith('copy')
+  })
+})

--- a/tests/svg-render-settings.spec.ts
+++ b/tests/svg-render-settings.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  DEFAULT_SVG_RENDER_ON,
+  getSvgRenderOn,
+  resetSvgRenderOn,
+  setSvgRenderOn,
+  SVG_RENDER_ON_KEY,
+  subscribeSvgRenderOn,
+} from '../src/client/workbench/svg-render-settings.ts'
+
+afterEach(() => {
+  resetSvgRenderOn()
+  try {
+    localStorage.removeItem(SVG_RENDER_ON_KEY)
+  } catch { /* ignore */ }
+})
+
+describe('svg render switch defaults', () => {
+  it('defaults to on (能力移植自 svg-viewer，默认渲染)', () => {
+    expect(DEFAULT_SVG_RENDER_ON).toBe(true)
+    expect(getSvgRenderOn()).toBe(true)
+  })
+})
+
+describe('svg render switch persistence', () => {
+  it('persists the switch to localStorage and restores it', () => {
+    setSvgRenderOn(false)
+    expect(localStorage.getItem(SVG_RENDER_ON_KEY)).toBe('0')
+    expect(getSvgRenderOn()).toBe(false)
+    setSvgRenderOn(true)
+    expect(localStorage.getItem(SVG_RENDER_ON_KEY)).toBe('1')
+    expect(getSvgRenderOn()).toBe(true)
+  })
+})
+
+describe('subscribers', () => {
+  it('notify only on actual change', () => {
+    const seen: boolean[] = []
+    const off = subscribeSvgRenderOn((on) => { seen.push(on) })
+    setSvgRenderOn(false)
+    setSvgRenderOn(false) // 无变化不通知
+    setSvgRenderOn(true)
+    expect(seen).toEqual([false, true])
+    off()
+  })
+
+  it('stops notifying after unsubscribe', () => {
+    const seen: boolean[] = []
+    const off = subscribeSvgRenderOn((on) => { seen.push(on) })
+    off()
+    setSvgRenderOn(false)
+    expect(seen).toEqual([])
+  })
+})

--- a/tests/svg-tail.spec.ts
+++ b/tests/svg-tail.spec.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  extractSvgs,
+  isStandardSvg,
+  sanitizeSvg,
+  selectSvgTail,
+  SVG_RENDER_EXAMPLE,
+} from '../src/client/workbench/svg-tail.ts'
+import {
+  resetSvgRenderOn,
+  selectSvgTailGated,
+  setSvgRenderOn,
+} from '../src/client/workbench/svg-render-settings.ts'
+
+afterEach(() => {
+  resetSvgRenderOn()
+})
+
+function makeOwner(blocks: Array<{ kind: string; text?: string }>): unknown {
+  return {
+    turn: {
+      data: {
+        get(key: string) {
+          if (key !== 'turn-tail') return undefined
+          return { closing: { blocks } }
+        },
+      },
+    },
+  }
+}
+
+const SIMPLE_SVG =
+  '<svg width="120" height="60" xmlns="http://www.w3.org/2000/svg"><rect x="10" y="10" width="100" height="40" rx="8" fill="#4c8dff"/></svg>'
+
+describe('isStandardSvg', () => {
+  it('accepts a complete <svg>…</svg> with at least one element', () => {
+    expect(isStandardSvg(SIMPLE_SVG)).toBe(true)
+  })
+
+  it('rejects non-svg text', () => {
+    expect(isStandardSvg('hello world')).toBe(false)
+  })
+
+  it('rejects an unclosed svg', () => {
+    expect(isStandardSvg('<svg><rect/></svg')).toBe(false)
+  })
+
+  it('rejects an empty inner (no element)', () => {
+    expect(isStandardSvg('<svg width="10"></svg>')).toBe(false)
+  })
+
+  it('rejects nested <svg inside (cross-line garbage guard)', () => {
+    expect(isStandardSvg('<svg><svg></svg></svg>')).toBe(false)
+  })
+
+  it('rejects text mentioning <svg>…</svg> that swallowed a foreign closing tag', () => {
+    // 正文表格/字面量里 “<svg>…</svg>” 会跨行吃到别处的 </svg>，内部混入 <svg 字样
+    expect(isStandardSvg('<svg>见上表 <svg width="1"/></svg>')).toBe(false)
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(isStandardSvg(`\n  ${SIMPLE_SVG}\n`)).toBe(true)
+  })
+})
+
+describe('sanitizeSvg', () => {
+  it('strips script blocks', () => {
+    const raw = `<svg><script>alert(1)</script><rect/></svg>`
+    expect(sanitizeSvg(raw)).toBe('<svg><rect/></svg>')
+  })
+
+  it('strips foreignObject blocks', () => {
+    const raw = `<svg><foreignObject><div>x</div></foreignObject><rect/></svg>`
+    expect(sanitizeSvg(raw)).toBe('<svg><rect/></svg>')
+  })
+
+  it('strips on* event attributes', () => {
+    const raw = `<svg onload="alert(1)"><rect onclick="x()"/></svg>`
+    const clean = sanitizeSvg(raw)
+    expect(clean).not.toBeNull()
+    expect(clean).not.toContain('onload')
+    expect(clean).not.toContain('onclick')
+  })
+
+  it('returns null when the result is no longer a standard svg', () => {
+    expect(sanitizeSvg('not an svg')).toBeNull()
+  })
+})
+
+describe('extractSvgs', () => {
+  it('extracts a fenced ```svg block', () => {
+    const text = `先说明\n\n\`\`\`svg\n${SIMPLE_SVG}\n\`\`\`\n\n结束`
+    expect(extractSvgs(text)).toEqual([SIMPLE_SVG])
+  })
+
+  it('extracts a standalone <svg> tag in prose', () => {
+    const text = `结果如图：${SIMPLE_SVG} 就是这样`
+    expect(extractSvgs(text)).toEqual([SIMPLE_SVG])
+  })
+
+  it('dedupes when fence and prose hit the same svg', () => {
+    const text = `\`\`\`svg\n${SIMPLE_SVG}\n\`\`\`\n正文 ${SIMPLE_SVG}`
+    expect(extractSvgs(text)).toEqual([SIMPLE_SVG])
+  })
+
+  it('extracts multiple distinct svgs', () => {
+    const other = '<svg viewBox="0 0 10 10"><circle cx="5" cy="5" r="4" fill="red"/></svg>'
+    const text = `\`\`\`svg\n${SIMPLE_SVG}\n\`\`\`\n${other}`
+    expect(extractSvgs(text)).toEqual([SIMPLE_SVG, other])
+  })
+
+  it('returns empty for plain text and svg mentions that are not complete tags', () => {
+    expect(extractSvgs('普通文字，没有图')).toEqual([])
+    expect(extractSvgs('我说的是 <svg> 标签，但没有完整闭合')).toEqual([])
+  })
+
+  it('rejects garbage cross-line match but keeps a real svg', () => {
+    const text = `| a | b |\n|---|---|\n| <svg> | </svg> |\n\n${SIMPLE_SVG}`
+    expect(extractSvgs(text)).toEqual([SIMPLE_SVG])
+  })
+})
+
+describe('selectSvgTail', () => {
+  it('merges multiple text blocks before extracting (fence spanning blocks)', () => {
+    const owner = makeOwner([
+      { kind: 'text', text: '```svg\n' },
+      { kind: 'text', text: `${SIMPLE_SVG}\n` },
+      { kind: 'text', text: '```' },
+    ])
+    expect(selectSvgTail(owner)).toEqual([SIMPLE_SVG])
+  })
+
+  it('returns null when no closing tail exists', () => {
+    expect(selectSvgTail({ turn: { data: { get: () => undefined } } })).toBeNull()
+  })
+
+  it('returns null when no svg is present', () => {
+    expect(selectSvgTail(makeOwner([{ kind: 'text', text: '没有图' }]))).toBeNull()
+  })
+
+  it('ignores non-text blocks', () => {
+    const owner = makeOwner([
+      { kind: 'tool', text: SIMPLE_SVG },
+      { kind: 'text', text: SIMPLE_SVG },
+    ])
+    expect(selectSvgTail(owner)).toEqual([SIMPLE_SVG])
+  })
+
+  it('returns null for a malformed owner instead of throwing', () => {
+    expect(selectSvgTail(null)).toBeNull()
+    expect(selectSvgTail(undefined)).toBeNull()
+  })
+})
+
+describe('selectSvgTailGated (设置开关门控)', () => {
+  it('returns matches when the switch is on (default)', () => {
+    const owner = makeOwner([{ kind: 'text', text: SIMPLE_SVG }])
+    expect(selectSvgTailGated(owner)).toEqual([SIMPLE_SVG])
+  })
+
+  it('returns null when the switch is off', () => {
+    setSvgRenderOn(false)
+    const owner = makeOwner([{ kind: 'text', text: SIMPLE_SVG }])
+    expect(selectSvgTailGated(owner)).toBeNull()
+  })
+})
+
+describe('SVG_RENDER_EXAMPLE (设置面板 tip 示例)', () => {
+  it('is a legal standard svg (will actually render)', () => {
+    expect(isStandardSvg(SVG_RENDER_EXAMPLE)).toBe(true)
+    expect(sanitizeSvg(SVG_RENDER_EXAMPLE)).toBe(SVG_RENDER_EXAMPLE)
+  })
+})


### PR DESCRIPTION
## What

会话渲染增强：在 agent 回答尾部（`conversation.chat.turnTail` 扩展点）把回复中的标准 SVG 标签渲染为可视化卡片，并在卡片右上角提供 "..." 操作菜单。

- **渲染**：agent 回复中以 ```` ```svg ```` 围栏代码块或正文完整 `<svg>…</svg>` 标签输出的内容，在该条回答底部渲染为 SVG 卡片（逐张渲染，注入前做最小安全清洗：剥离 `script` / `foreignObject` / `on*` 事件属性）；
- **开关**：设置面板新增「会话渲染增强」分区，含「渲染会话中的 SVG 标签」开关（localStorage 持久化，默认开启）；关闭时 select 返回 null 不匹配、不渲染；
- **卡片操作菜单**：每张卡片右上角 "..." 按钮，提供 ① 下载为 HTML（独立文档）② 下载为图片（canvas 栅格化 PNG，viewBox/尺寸解析 + 白底 + 2x）③ 复制代码（Clipboard API + execCommand 降级，浮动提示反馈）。

## Why

DSH 会话中 agent 常以 ```` ```svg ```` 围栏输出架构图 / 示意图，目前只能看到代码。此功能把标准 SVG 直接可视化为卡片，便于对照与导出。

## 改动清单（13 文件，+925/-8，纯源码 + 测试，不含 lib）

| 文件 | 改动 |
|---|---|
| `src/client/index.ts` | +3 import；`registerWorkbenchLocale` 运行时合并外移翻译；末尾 +1 个 `conversation.chat.turnTail` 注册（select 门控） |
| `src/client/workbench/svg-tail.ts` | 新文件：纯逻辑（无 React/DOM）——`isStandardSvg` / `sanitizeSvg` / `extractSvgs`（围栏优先 + 正文完整标签 + 去重）/ `selectSvgTail` / 设置面板 tip 示例常量 |
| `src/client/workbench/svg-render-settings.ts` | 新文件：开关偏好 store（localStorage 持久化）`get/set/subscribeSvgRenderOn` + `useSvgRenderOn` hook + `selectSvgTailGated` 门控 select |
| `src/client/workbench/svg-render-locales.ts` | 新文件：中英翻译 key（`settings.section.svgRender` 等 10 个）——外移独立模块，避免逐行插入 locales.ts |
| `src/client/workbench/SvgTailView.tsx` | 新文件：turnTail 卡片渲染视图（`matched` 逐张清洗注入）+ "..." 菜单（IconMore + ContextMenu） |
| `src/client/workbench/SvgTailView.module.css` | 新文件：卡片样式（主题变量适配明暗模式） |
| `src/client/workbench/svg-card-actions.ts` | 新文件：纯函数操作模块——`svgToHtml` / `downloadBlob` / `svgViewSize` / `svgToPng` / `copyText` |
| `src/client/workbench/SettingsPanel.tsx` | +1 折叠分区（③ 会话渲染增强）：开关行 + tip 说明（含合法 SVG 示例） |
| `src/client/workbench/SettingsPanel.module.css` | +`.svgRenderTip` 等 3 个类 |
| `src/client/workbench/ui-flags.ts` | +`SETTINGS_SVG_RENDER_OPEN_KEY` / `DEFAULT_SETTINGS_SVG_RENDER_OPEN`（各 1 行） |
| `tests/svg-tail.spec.ts` | 新文件：提取/校验/清洗/门控矩阵 + tip 示例合法性断言（25 条） |
| `tests/svg-render-settings.spec.ts` | 新文件：开关默认值/持久化/订阅/复位（4 条） |
| `tests/svg-card-actions.spec.ts` | 新文件：HTML 包装 / 尺寸解析 / 下载触发 / 复制双路径（8 条） |

## 设计决策（Why 与 What）

| 决策 | 理由 |
|------|------|
| 挂钩 `conversation.chat.turnTail` 链 | 官方扩展点（replaceRisk: none），不抢占 shipped UI；select 路由 + 视图组件挂载 |
| 开关门控放在 select 内部 | 关闭时返回 null 不匹配不渲染，切换即时生效，无需重挂载 |
| 标准校验 `isStandardSvg` | 只认完整 `<svg …>…</svg>`（开头 + 结尾 + 内部至少一元素 + 内部不再嵌套 `<svg`），防跨行垃圾匹配，不刻意兼容 |
| 操作逻辑独立成纯函数模块 | 可独立单测；与视图解耦 |
| 翻译外移独立模块 | 不逐行插入 locales.ts（上游合并最高频冲突文件），注册时运行时合并 |

## 注意事项（给维护者）

- **本 PR 不含构建产物**（lib/client.js 等）——本地重建会产生 CSS hash 无关噪声。请合并后运行 `bash devops/build.sh` 重新构建。
- 开关默认开启；localStorage key：`dsh-workbench-svg-render-on`。
- 测试：3 个新 spec 共 37 条用例全过（`pnpm test` 全量 689 通过，唯一失败为环境固有的 net-ref-machine 硬编码路径用例）。
